### PR TITLE
Minor fixes for TrainingSceneObjects

### DIFF
--- a/Editor/Source/SceneObjects/SceneObjectEditor.cs
+++ b/Editor/Source/SceneObjects/SceneObjectEditor.cs
@@ -1,16 +1,29 @@
 ﻿using UnityEditor;
 using UnityEngine;
+using System.Reflection;
 using Innoactive.Hub.Training.SceneObjects;
 using Innoactive.Hub.Training.SceneObjects.Properties;
 
 namespace Innoactive.Hub.Training.Editors.SceneObjects
 {
     /// <summary>
-    /// This class keeps track of TrainingSceneEntities and adds names to newly added entities.
+    /// This class adds names to newly added entities.
     /// </summary>
     [CustomEditor(typeof(TrainingSceneObject))]
     public class SceneObjectEditor : Editor
     {
+        private void OnEnable()
+        {
+            ISceneObject sceneObject = target as ISceneObject;
+            FieldInfo fieldInfoObj = sceneObject.GetType().GetField("uniqueName", BindingFlags.NonPublic | BindingFlags.Instance);
+            string uniqueName = fieldInfoObj.GetValue(sceneObject) as string;
+
+            if (string.IsNullOrEmpty(uniqueName))
+            {
+                sceneObject.SetSuitableName();
+            }
+        }
+
         [MenuItem ("CONTEXT/TrainingSceneObject/Remove Training Properties", false)]
         private static void RemoveTrainingProperties()
         {

--- a/Source/SceneObjects/TrainingSceneObject.cs
+++ b/Source/SceneObjects/TrainingSceneObject.cs
@@ -73,7 +73,10 @@ namespace Innoactive.Hub.Training.SceneObjects
 
         private void OnDestroy()
         {
-            RuntimeConfigurator.Configuration.SceneObjectRegistry.Unregister(this);
+            if (RuntimeConfigurator.Exists)
+            {
+                RuntimeConfigurator.Configuration.SceneObjectRegistry.Unregister(this);
+            }
         }
 
         public bool CheckHasProperty<T>() where T : ISceneObjectProperty


### PR DESCRIPTION
### Description:
chg: SceneObjecteditor now ensures the TrainingSceneObject has a valid UniqueName.
chg: TrainingSceneObject validates that RuntimeConfigurator exits before unregistering when it is destroyed.

### Resolves:

#### The first `TrainingSceneObject` added in a new scene doesn't have a `unique name`.

1. Create a new scene.
2. Set scene as a training scene.
3. Add an empty game object.
4. Add TrainingSceneObject it.

#### The first `TrainingSceneObject` added in a new scene throws an error when the scene is unloaded.

1. Create a new scene.
2. Set scene as a training scene.
3. Add an empty game object.
4. Add TrainingSceneObject it.
5. **Ctrl** + **N**

`NullReferenceException: Training runtime configurator is not set in the scene. Create an empty game object with the 'RuntimeConfigurator' script attached to it.`

#### The first `TrainingSceneObject` added in a new scene throws an error every time the scene starts playing.

1. Create a new scene.
2. Set scene as a training scene.
3. Add an empty game object.
4. Add TrainingSceneObject it.
5. Play the scene.

`NullReferenceException: Training runtime configurator is not set in the scene. Create an empty game object with the 'RuntimeConfigurator' script attached to it.`