### PR TITLE
The API compatibility level is no longer checked in Unity 2018.4 or newer.

### DIFF
--- a/Source/Utils/Unity/UnityDotNetCheck.cs
+++ b/Source/Utils/Unity/UnityDotNetCheck.cs
@@ -3,10 +3,9 @@
 // succeed before running, which isn't the case for .Net subset.
 // If Scripting Runtime Version is .NET 4.X, Api Compatibility Level 4.X is required, since the
 // .Net Standard 2.0 does not provide access to Win32.Registry.
+
 #if NET_2_0_SUBSET
 #error This Unity project is configured for .Net 2.0 subset, but the Innoactive Hub SDK requires full .Net functionality. Please go to "PlayerSettings > Other Settings" and change Api Compatibility Level to .Net 4.X.
-#elif NET_STANDARD_2_0
+#elif NET_STANDARD_2_0 && !UNITY_2018_3_OR_NEWER
 #error This Unity project is configured for Scripting Runtime Version 4.X, but uses Api Compatibility for .Net Standard 2.0. The Innoactive Hub SDK requires Api Compatibility level 4.X. Please go to "PlayerSettings > Other Settings" and change Api Compatibility Level to .Net 4.X.
 #endif
-
-


### PR DESCRIPTION
### Description:

- chg: .Net compatibility level is only checked in Unity versions older than 2018.3

### Notes:

The `.Net 2.0 Subset` version was removed in `Unity 2018.3`, so there is no need to force users in newer versions to switch from `.Net Standard 2.0` to `.Net 4.x`.
 
Tested in the following versions:

![image](https://user-images.githubusercontent.com/6911992/73836462-9b927f00-480f-11ea-9751-68d53b1dd28f.png)
