### PR TITLE
chg: Added a fix for missing scripts in VRTK-Setup prefab

### DIFF
--- a/Editor/Source/Configuration/DefaultEditorConfiguration.cs
+++ b/Editor/Source/Configuration/DefaultEditorConfiguration.cs
@@ -132,7 +132,7 @@ namespace Innoactive.Hub.Training.Editors.Configuration
             }
             else if (ContainsMissingScripts(vrtkSetup))
             {
-                if (EditorUtility.DisplayDialog("Broken VRTK Setup found", "Your VRTK-Setup requires the hub-sdk, do you want to replace it with a new one which dosen't?", "Replace", "Cancel"))
+                if (EditorUtility.DisplayDialog("Broken VRTK Setup found", "Your VRTK setup requires the Hub-SDK, do you want to replace it?", "Replace", "Cancel"))
                 {
                     GameObject.DestroyImmediate(vrtkSetup);
                     GameObject prefab = (GameObject)GameObject.Instantiate(Resources.Load("[VRTK_Setup]", typeof(GameObject)));


### PR DESCRIPTION
* On scene setup we now check VRTK-Setup prefab for missing scripts and allow to replace it with a working version.