### PR TITLE
Make it possible to update docu of existing release.

### DIFF
--- a/.JenkinsFile
+++ b/.JenkinsFile
@@ -110,7 +110,7 @@ pipeline
             {
                 anyOf 
                 {
-                    tag pattern: "v(\\d+\\.\\d+\\.\\d+)", comparator: "REGEXP"
+                    tag pattern: "v(\\d+\\.\\d+\\.\\d+(-docu)?)", comparator: "REGEXP"
                     expression { params.BUILD_DOCUMENTATION == true }
                 }
             }
@@ -164,7 +164,7 @@ pipeline
                 {
                     when
                     {
-                        tag pattern: "v(\\d+\\.\\d+\\.\\d+)", comparator: "REGEXP"
+                        tag pattern: "v(\\d+\\.\\d+\\.\\d+(-docu)?)", comparator: "REGEXP"
                     }
                     steps
                     {

--- a/.JenkinsFile-Shared
+++ b/.JenkinsFile-Shared
@@ -114,6 +114,9 @@ def Documentation()
 def DeployDocumentation()
 {
     echo 'Upload documentation to ftp server'
+
+    def tagNameNoPostfix = env.TAG_NAME.split('-')[0];
+
     dir("${PROJECT_PATH}")
     {
         // upload documentation to ftp server
@@ -129,7 +132,7 @@ def DeployDocumentation()
                         makeEmptyDirs: false,
                         noDefaultExcludes: false,
                         patternSeparator: '[, ]+',
-                        remoteDirectory: "${TAG_NAME}",
+                        remoteDirectory: tagNameNoPostfix,
                         remoteDirectorySDF: false,
                         removePrefix: 'Assets/Innoactive/Creator/Core/.Documentation/_site/',
                         sourceFiles: 'Assets/Innoactive/Creator/Core/.Documentation/_site/**/*'


### PR DESCRIPTION
Replace docu of vX.Y.Z if the build tag is vX.Y.Z-docu

This way we will still know the commit we got our build from (v1.3.1), but we are able to override the documentation if we put the v1.3.1-docu on the other commit.

This way it is transparent where both a build and its docu have came from.