### PR TITLE
Steps lock/unlock training properties and their dependencies TRNG-55

### DIFF
--- a/.dependencies.json
+++ b/.dependencies.json
@@ -3,7 +3,7 @@
         {
             "name": "Components\\VRTK-Interaction",
             "repository": "git@github.com:Innoactive/VRTK-Interaction-Component.git",
-            "branch": "develop"
+            "branch": "feature/autolocking-TRNG55"
         },
         {
             "name": "Components\\Text-To-Speech",
@@ -13,12 +13,12 @@
         {
             "name": "Components\\Basic-Interaction",
             "repository": "git@github.com:Innoactive/Basic-Interaction-Component.git",
-            "branch": "develop"
+            "branch": "feature/autolocking-TRNG55"
         },
         {
             "name": "Components\\Basic-Behaviors-And-Conditions",
             "repository": "git@github.com:Innoactive/Basic-Conditions-And-Behaviors.git",
-            "branch": "develop"
+            "branch": "feature/lockable-environment-TRNG55"
         }
     ]
 }

--- a/Runtime/Properties/LockableProperty.cs
+++ b/Runtime/Properties/LockableProperty.cs
@@ -11,17 +11,11 @@ namespace Innoactive.Creator.Core.Properties
 
         [SerializeField]
         private bool lockOnParentObjectLock = true;
-        
+
         public bool LockOnParentObjectLock
         {
-            get
-            {
-                return lockOnParentObjectLock;
-            }
-            set
-            {
-                lockOnParentObjectLock = value;
-            }
+            get => lockOnParentObjectLock;
+            set => lockOnParentObjectLock = value;
         }
 
         public bool IsLocked { get; private set; }

--- a/Runtime/RestrictiveEnvironment/PropertyReflectionHelper.cs
+++ b/Runtime/RestrictiveEnvironment/PropertyReflectionHelper.cs
@@ -62,7 +62,7 @@ namespace Innoactive.Creator.Core
 
                 if (refType != null)
                 {
-                    result.Add(new LockablePropertyData(GetProperty(reference, refType)));
+                    result.AddRange(GetAllDependenciesFrom(refType).Select(type => new LockablePropertyData(GetProperty(reference, type))));
                 }
             });
 
@@ -81,6 +81,34 @@ namespace Innoactive.Creator.Core
             }
             Debug.LogWarningFormat("Could not find fitting {0} type in SceneObject {1}", type.Name, reference.UniqueName);
             return null;
+        }
+
+        private static HashSet<Type> GetAllDependenciesFrom(Type trainingProperty)
+        {
+            HashSet<Type> dependencies = new HashSet<Type>();
+            RequireComponent[] requireComponents = trainingProperty.GetCustomAttributes(typeof(RequireComponent), false) as RequireComponent[];
+
+            if (requireComponents.Any())
+            {
+                foreach (RequireComponent requireComponent in requireComponents)
+                {
+                    AddTypeToList(requireComponent.m_Type0, ref dependencies);
+                    AddTypeToList(requireComponent.m_Type1, ref dependencies);
+                    AddTypeToList(requireComponent.m_Type2, ref dependencies);
+                }
+            }
+
+            AddTypeToList(trainingProperty, ref dependencies);
+
+            return dependencies;
+        }
+
+        private static void AddTypeToList(Type type, ref HashSet<Type> dependencies)
+        {
+            if (type != null)
+            {
+                dependencies.Add(type);
+            }
         }
     }
 }

--- a/Runtime/RestrictiveEnvironment/PropertyReflectionHelper.cs
+++ b/Runtime/RestrictiveEnvironment/PropertyReflectionHelper.cs
@@ -86,15 +86,15 @@ namespace Innoactive.Creator.Core
         private static IEnumerable<Type> GetLockableDependenciesFrom(Type trainingProperty)
         {
             List<Type> dependencies = new List<Type>();
-            IEnumerable<Type> requireComponents = trainingProperty.GetCustomAttributes(typeof(RequireComponent), false)
+            IEnumerable<Type> requiredComponents = trainingProperty.GetCustomAttributes(typeof(RequireComponent), false)
                 .Cast<RequireComponent>()
                 .SelectMany(rq => new []{rq.m_Type0, rq.m_Type1, rq.m_Type2});
 
-            foreach (Type requireComponent in requireComponents)
+            foreach (Type requiredComponent in requiredComponents)
             {
-                if (requireComponent != null && requireComponent.IsSubclassOf(typeof(LockableProperty)))
+                if (requiredComponent != null && requiredComponent.IsSubclassOf(typeof(LockableProperty)))
                 {
-                    dependencies.AddRange(GetLockableDependenciesFrom(requireComponent));
+                    dependencies.AddRange(GetLockableDependenciesFrom(requiredComponent));
                 }
             }
 

--- a/Runtime/RestrictiveEnvironment/PropertyReflectionHelper.cs
+++ b/Runtime/RestrictiveEnvironment/PropertyReflectionHelper.cs
@@ -9,7 +9,6 @@ using Innoactive.Creator.Core.RestrictiveEnvironment;
 using Innoactive.Creator.Core.SceneObjects;
 using Innoactive.Creator.Core.Utils;
 using UnityEngine;
-using UnityEngine.Rendering;
 
 namespace Innoactive.Creator.Core
 {


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

Every step unlocks at its start all the scene objects that have at least one `Lockable Property` and their dependencies and then lock them back at the end of its execution.

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Create a new training course and play around with multiple steps and different variants between `Touch Condition`, `Grab Condition`, `Use Condition`, `Snap Condition`.