### PR TITLE
feat: add tabs to the Step Inspector

### DIFF
--- a/Editor/DefaultEditingStrategy.cs
+++ b/Editor/DefaultEditingStrategy.cs
@@ -37,7 +37,14 @@ namespace Innoactive.CreatorEditor
 
             stepWindow = window;
 
-            HandleCurrentStepChanged(courseWindow.GetChapter().ChapterMetadata.LastSelectedStep);
+            if (courseWindow == null || courseWindow.Equals(null))
+            {
+                HandleCurrentStepChanged(null);
+            }
+            else
+            {
+                HandleCurrentStepChanged(courseWindow.GetChapter().ChapterMetadata.LastSelectedStep);
+            }
         }
 
         /// <inheritdoc/>

--- a/Editor/UI/Drawers/ListDrawer.cs
+++ b/Editor/UI/Drawers/ListDrawer.cs
@@ -29,9 +29,12 @@ namespace Innoactive.CreatorEditor.UI.Drawers
                 fontSize = 12
             };
 
-            EditorGUI.LabelField(new Rect(rect.x, currentY, rect.width, EditorDrawingHelper.HeaderLineHeight), label, labelStyle);
+            if (label != null && label != GUIContent.none && (label.image != null || string.IsNullOrEmpty(label.text) == false))
+            {
+                EditorGUI.LabelField(new Rect(rect.x, currentY, rect.width, EditorDrawingHelper.HeaderLineHeight), label, labelStyle);
+                currentY += EditorDrawingHelper.HeaderLineHeight;
+            }
 
-            currentY += EditorDrawingHelper.HeaderLineHeight;
 
             object[] entries = new object[list.Count];
             list.CopyTo(entries, 0);

--- a/Editor/UI/Drawers/ObjectDrawer.cs
+++ b/Editor/UI/Drawers/ObjectDrawer.cs
@@ -71,6 +71,11 @@ namespace Innoactive.CreatorEditor.UI.Drawers
         /// </summary>
         protected virtual float DrawLabel(Rect rect, object currentValue, Action<object> changeValueCallback, GUIContent label)
         {
+            if (label == GUIContent.none || label == null || (label.image == null && string.IsNullOrEmpty(label.text)))
+            {
+                return 0;
+            }
+
             GUIStyle labelStyle = new GUIStyle(EditorStyles.label)
             {
                 fontStyle = FontStyle.Bold,

--- a/Editor/UI/Drawers/StepDrawer.cs
+++ b/Editor/UI/Drawers/StepDrawer.cs
@@ -35,6 +35,8 @@ namespace Innoactive.CreatorEditor.UI.Drawers
                 fontSize = 12
             };
 
+            rect.height = labelStyle.CalcHeight(new GUIContent("Step Name"), rect.width);
+
             EditorGUI.LabelField(typeRect, "Step Name", labelStyle);
 
             string oldName = step.Name;

--- a/Editor/UI/Drawers/TabsGroupDrawer.cs
+++ b/Editor/UI/Drawers/TabsGroupDrawer.cs
@@ -38,7 +38,8 @@ namespace Innoactive.CreatorEditor.UI.Drawers
 
             float height = EditorStyles.toolbar.fixedHeight;
             nextPosition.position += new Vector2(0, height);
-            return DrawerLocator.GetDrawerForValue(tabsGroup.Tabs[tabsGroup.Selected].GetValue(), typeof(object))
+            rect.height = EditorStyles.toolbar.fixedHeight
+                + DrawerLocator.GetDrawerForValue(tabsGroup.Tabs[tabsGroup.Selected].GetValue(), typeof(object))
                 .Draw(nextPosition,
                     tabsGroup.Tabs[tabsGroup.Selected].GetValue(),
                     (newValue) =>
@@ -46,7 +47,9 @@ namespace Innoactive.CreatorEditor.UI.Drawers
                         tabsGroup.Tabs[tabsGroup.Selected].SetValue(newValue);
                         changeValueCallback(tabsGroup);
                     },
-                    GUIContent.none);
+                    GUIContent.none).height;
+
+            return rect;
         }
     }
 }

--- a/Editor/UI/Drawers/TabsGroupDrawer.cs
+++ b/Editor/UI/Drawers/TabsGroupDrawer.cs
@@ -13,13 +13,36 @@ namespace Innoactive.CreatorEditor.UI.Drawers
         {
             ITabsGroup tabsGroup = (ITabsGroup)currentValue;
 
+            // Draw tabs selector.
+            float tabsHeight = DrawToolbox(rect, tabsGroup, changeValueCallback).height;
+
+
+            // Get drawer for the object under the tab.
+            ITrainingDrawer tabValueDrawer = DrawerLocator.GetDrawerForValue(tabsGroup.Tabs[tabsGroup.Selected].GetValue(), typeof(object));
+
+            void ChangeValueCallback(object newValue)
+            {
+                tabsGroup.Tabs[tabsGroup.Selected].SetValue(newValue);
+                changeValueCallback(tabsGroup);
+            }
+
+            Rect tabValueRect = new Rect(rect.x, rect.y + tabsHeight, rect.width, 0);
+
+            // Draw the object under the tab.
+            rect.height = tabsHeight + tabValueDrawer.Draw(tabValueRect, tabsGroup.Tabs[tabsGroup.Selected].GetValue(), ChangeValueCallback, GUIContent.none).height;
+
+            return rect;
+        }
+
+        private Rect DrawToolbox(Rect rect, ITabsGroup tabsGroup, Action<object> changeValueCallback)
+        {
+            rect.height = EditorStyles.toolbar.fixedHeight;
+
             GUIContent[] labels = tabsGroup.Tabs.Select(tab => tab.Label).ToArray();
 
             int oldSelected = tabsGroup.Selected;
 
-            Rect nextPosition = new Rect(rect.x, rect.y, rect.width, EditorStyles.toolbar.fixedHeight);
-
-            int selected = GUI.Toolbar(nextPosition, oldSelected, labels);
+            int selected = GUI.Toolbar(rect, oldSelected, labels);
 
             if (selected != oldSelected)
             {
@@ -35,19 +58,6 @@ namespace Innoactive.CreatorEditor.UI.Drawers
                     },
                     changeValueCallback);
             }
-
-            float height = EditorStyles.toolbar.fixedHeight;
-            nextPosition.position += new Vector2(0, height);
-            rect.height = EditorStyles.toolbar.fixedHeight
-                + DrawerLocator.GetDrawerForValue(tabsGroup.Tabs[tabsGroup.Selected].GetValue(), typeof(object))
-                .Draw(nextPosition,
-                    tabsGroup.Tabs[tabsGroup.Selected].GetValue(),
-                    (newValue) =>
-                    {
-                        tabsGroup.Tabs[tabsGroup.Selected].SetValue(newValue);
-                        changeValueCallback(tabsGroup);
-                    },
-                    GUIContent.none).height;
 
             return rect;
         }

--- a/Editor/UI/Drawers/TabsGroupDrawer.cs
+++ b/Editor/UI/Drawers/TabsGroupDrawer.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using Innoactive.Creator.Core.Tabs;
+using UnityEditor;
+using UnityEngine;
+
+namespace Innoactive.CreatorEditor.UI.Drawers
+{
+    [DefaultTrainingDrawer(typeof(ITabsGroup))]
+    internal class TabsGroupDrawer : AbstractDrawer
+    {
+        public override Rect Draw(Rect rect, object currentValue, Action<object> changeValueCallback, GUIContent label)
+        {
+            ITabsGroup tabsGroup = (ITabsGroup)currentValue;
+
+            GUIContent[] labels = tabsGroup.Tabs.Select(tab => tab.Label).ToArray();
+
+            int oldSelected = tabsGroup.Selected;
+
+            Rect nextPosition = new Rect(rect.x, rect.y, rect.width, EditorStyles.toolbar.fixedHeight);
+
+            int selected = GUI.Toolbar(nextPosition, oldSelected, labels);
+
+            if (selected != oldSelected)
+            {
+                ChangeValue(() =>
+                    {
+                        tabsGroup.Selected = selected;
+                        return tabsGroup;
+                    },
+                    () =>
+                    {
+                        tabsGroup.Selected = oldSelected;
+                        return tabsGroup;
+                    },
+                    changeValueCallback);
+            }
+
+            float height = EditorStyles.toolbar.fixedHeight;
+            nextPosition.position += new Vector2(0, height);
+            return DrawerLocator.GetDrawerForValue(tabsGroup.Tabs[tabsGroup.Selected].GetValue(), typeof(object))
+                .Draw(nextPosition,
+                    tabsGroup.Tabs[tabsGroup.Selected].GetValue(),
+                    (newValue) =>
+                    {
+                        tabsGroup.Tabs[tabsGroup.Selected].SetValue(newValue);
+                        changeValueCallback(tabsGroup);
+                    },
+                    GUIContent.none);
+        }
+    }
+}

--- a/Editor/UI/Drawers/TabsGroupDrawer.cs.meta
+++ b/Editor/UI/Drawers/TabsGroupDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7223d734d5a34556a47ae4511ea09959
+timeCreated: 1593120854

--- a/Editor/UI/Drawers/UniqueNameReferenceDrawer.cs
+++ b/Editor/UI/Drawers/UniqueNameReferenceDrawer.cs
@@ -44,7 +44,6 @@ namespace Innoactive.CreatorEditor.UI.Drawers
 
             if (oldUniqueName != newUniqueName)
             {
-
                 RevertableChangesHandler.Do(
                     new CourseCommand(
                         () =>

--- a/Editor/UI/Windows/CourseWindow.cs
+++ b/Editor/UI/Windows/CourseWindow.cs
@@ -122,7 +122,7 @@ namespace Innoactive.CreatorEditor.UI.Windows
             chapterMenu.Draw();
             DrawChapterWorkflow(scrollRect);
 
-            Repaint();
+            //Repaint();
         }
 
         private void OnDestroy()

--- a/Editor/UI/Windows/CourseWindow.cs
+++ b/Editor/UI/Windows/CourseWindow.cs
@@ -121,8 +121,6 @@ namespace Innoactive.CreatorEditor.UI.Windows
             HandleEditorCommands(centerViewpointOnCanvas);
             chapterMenu.Draw();
             DrawChapterWorkflow(scrollRect);
-
-            //Repaint();
         }
 
         private void OnDestroy()
@@ -181,6 +179,11 @@ namespace Innoactive.CreatorEditor.UI.Windows
             {
                 Rect controlRect = new Rect(currentScrollPosition, scrollRect.size);
                 chapterRepresentation.HandleEvent(Event.current, controlRect);
+
+                if (Event.current.type == EventType.Used)
+                {
+                    Repaint();
+                }
             }
             GUI.EndScrollView();
         }

--- a/Editor/UI/Windows/StepWindow.cs
+++ b/Editor/UI/Windows/StepWindow.cs
@@ -24,6 +24,8 @@ namespace Innoactive.CreatorEditor.UI.Windows
 
         public static event EventHandler<StepModifiedEventArgs> StepChanged;
 
+        private const int border = 4;
+
         private IStep step;
 
         [SerializeField]
@@ -75,14 +77,16 @@ namespace Innoactive.CreatorEditor.UI.Windows
 
             stepRect.width = position.width;
 
-            if (stepRect.height > position.height - EditorGUIUtility.singleLineHeight)
+            if (stepRect.height > position.height)
             {
                 stepRect.width -= GUI.skin.verticalScrollbar.fixedWidth;
             }
 
             scrollPosition = GUI.BeginScrollView(new Rect(0, 0, position.width, position.height), scrollPosition, stepRect, false, false);
             {
-                stepRect = drawer.Draw(stepRect, step, ModifyStep, "Step");
+                Rect stepDrawingRect = new Rect(stepRect.position + new Vector2(border, border), stepRect.size - new Vector2(border * 2f, border * 2f));
+                stepDrawingRect = drawer.Draw(stepDrawingRect, step, ModifyStep, "Step");
+                stepRect = new Rect(stepDrawingRect.position - new Vector2(border,border), stepDrawingRect.size + new Vector2(border * 2f, border * 2f));
             }
             GUI.EndScrollView();
         }

--- a/Runtime/Attributes/KeepPopulatedAttribute.cs
+++ b/Runtime/Attributes/KeepPopulatedAttribute.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Reflection;
-using System.Runtime.Serialization;
-using Innoactive.Creator.Core.Utils;
 
 namespace Innoactive.Creator.Core.Attributes
 {

--- a/Runtime/BehaviorCollection.cs
+++ b/Runtime/BehaviorCollection.cs
@@ -25,7 +25,7 @@ namespace Innoactive.Creator.Core
             /// List of all <see cref="IBehavior"/>s added.
             /// </summary>
             [DataMember]
-            [DisplayName("Behaviors"), ListOf(typeof(FoldableAttribute), typeof(DeletableAttribute), typeof(SeparatedAttribute), typeof(DrawIsBlockingToggleAttribute)), ExtendableList]
+            [DisplayName(""), ListOf(typeof(FoldableAttribute), typeof(DeletableAttribute), typeof(DrawIsBlockingToggleAttribute)), ExtendableList]
             public virtual IList<IBehavior> Behaviors { get; set; }
 
             /// <summary>

--- a/Runtime/BehaviorCollection.cs
+++ b/Runtime/BehaviorCollection.cs
@@ -25,7 +25,7 @@ namespace Innoactive.Creator.Core
             /// List of all <see cref="IBehavior"/>s added.
             /// </summary>
             [DataMember]
-            [DisplayName("Behaviors"), Separated, Foldable, ListOf(typeof(FoldableAttribute), typeof(DeletableAttribute), typeof(SeparatedAttribute), typeof(DrawIsBlockingToggleAttribute)), ExtendableList]
+            [DisplayName("Behaviors"), ListOf(typeof(FoldableAttribute), typeof(DeletableAttribute), typeof(SeparatedAttribute), typeof(DrawIsBlockingToggleAttribute)), ExtendableList]
             public virtual IList<IBehavior> Behaviors { get; set; }
 
             /// <summary>

--- a/Runtime/Behaviors/Behavior.cs
+++ b/Runtime/Behaviors/Behavior.cs
@@ -1,6 +1,5 @@
 ﻿using UnityEngine;
 using System.Runtime.Serialization;
-using Innoactive.Creator.Core.Configuration;
 using Innoactive.Creator.Core.Utils.Logging;
 using Innoactive.Creator.Unity;
 

--- a/Runtime/Configuration/Modes/BaseModeHandler.cs
+++ b/Runtime/Configuration/Modes/BaseModeHandler.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using Innoactive.Creator.Core.Configuration.Modes;
 using Innoactive.Creator.Core.Exceptions;
 
 namespace Innoactive.Creator.Core.Configuration.Modes

--- a/Runtime/Configuration/Modes/ModeChangedEventArgs.cs
+++ b/Runtime/Configuration/Modes/ModeChangedEventArgs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Innoactive.Creator.Core.Configuration.Modes;
 
 namespace Innoactive.Creator.Core.Configuration.Modes
 {

--- a/Runtime/Configuration/Modes/ModeParameter.cs
+++ b/Runtime/Configuration/Modes/ModeParameter.cs
@@ -1,5 +1,4 @@
 using System;
-using Innoactive.Creator.Core.Configuration.Modes;
 
 namespace Innoactive.Creator.Core.Configuration.Modes
 {

--- a/Runtime/Configuration/RuntimeConfigurator.cs
+++ b/Runtime/Configuration/RuntimeConfigurator.cs
@@ -2,7 +2,6 @@ using System;
 using Innoactive.Creator.Core.Configuration.Modes;
 using Innoactive.Creator.Core.Utils;
 using UnityEngine;
-using UnityEngine.Serialization;
 
 namespace Innoactive.Creator.Core.Configuration
 {

--- a/Runtime/RestrictiveEnvironment/LockableHandling.cs
+++ b/Runtime/RestrictiveEnvironment/LockableHandling.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using UnityEngine;
 
 namespace Innoactive.Creator.Core.RestrictiveEnvironment
 {

--- a/Runtime/SceneObjects/SceneObjectExtensions.cs
+++ b/Runtime/SceneObjects/SceneObjectExtensions.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using System.Reflection;
 using Innoactive.Creator.Core.Configuration;
 using Innoactive.Creator.Core.SceneObjects;
 using Innoactive.Creator.Core.Utils;

--- a/Runtime/SceneObjects/ScenePropertyReference.cs
+++ b/Runtime/SceneObjects/ScenePropertyReference.cs
@@ -2,7 +2,6 @@
 using System.Runtime.Serialization;
 using Innoactive.Creator.Core.Configuration;
 using Innoactive.Creator.Core.Properties;
-using UnityEngine;
 
 namespace Innoactive.Creator.Core.SceneObjects
 {

--- a/Runtime/Step.cs
+++ b/Runtime/Step.cs
@@ -9,6 +9,7 @@ using Innoactive.Creator.Core.Configuration.Modes;
 using Innoactive.Creator.Core.EntityOwners;
 using Innoactive.Creator.Core.EntityOwners.FoldedEntityCollection;
 using Innoactive.Creator.Core.RestrictiveEnvironment;
+using Innoactive.Creator.Core.Tabs;
 using Innoactive.Creator.Core.Utils.Logging;
 using Innoactive.Creator.Unity;
 
@@ -33,12 +34,17 @@ namespace Innoactive.Creator.Core
             [DrawingPriority(1)]
             public string Description { get; set; }
 
+            [DataMember]
+            private ITabsGroup Tabs { get; set; }
+
             ///<inheritdoc />
             [DataMember]
+            [HideInTrainingInspector]
             public IBehaviorCollection Behaviors { get; set; }
 
             ///<inheritdoc />
             [DataMember]
+            [HideInTrainingInspector]
             public ITransitionCollection Transitions { get; set; }
 
             ///<inheritdoc />
@@ -58,7 +64,16 @@ namespace Innoactive.Creator.Core
             public IMode Mode { get; set; }
 
             ///<inheritdoc />
+            [HideInTrainingInspector]
             public IEnumerable<LockablePropertyReference> ToUnlock { get; set; } = new List<LockablePropertyReference>();
+
+            public EntityData()
+            {
+                Tabs = new TabsGroup(
+                    new DynamicTab(new GUIContent("Behaviors"), () => Behaviors, value => Behaviors = (IBehaviorCollection)value),
+                    new DynamicTab(new GUIContent("Transitions"), () => Transitions, value => Transitions = (ITransitionCollection)value)
+                );
+            }
         }
 
         private class ActiveProcess : Process<EntityData>

--- a/Runtime/Tabs.meta
+++ b/Runtime/Tabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 932b2c6effaf1cf41b63e1b0b3d6b7c9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Tabs/DynamicTab.cs
+++ b/Runtime/Tabs/DynamicTab.cs
@@ -1,0 +1,30 @@
+using System;
+using UnityEngine;
+
+namespace Innoactive.Creator.Core.Tabs
+{
+    internal class DynamicTab : ITab
+    {
+        public GUIContent Label { get; }
+
+        public object GetValue()
+        {
+            return getter();
+        }
+
+        public void SetValue(object value)
+        {
+            setter(value);
+        }
+
+        private readonly Func<object> getter;
+        private readonly Action<object> setter;
+
+        public DynamicTab(GUIContent label, Func<object> getter, Action<object> setter)
+        {
+            Label = label;
+            this.getter = getter;
+            this.setter = setter;
+        }
+    }
+}

--- a/Runtime/Tabs/DynamicTab.cs
+++ b/Runtime/Tabs/DynamicTab.cs
@@ -3,6 +3,9 @@ using UnityEngine;
 
 namespace Innoactive.Creator.Core.Tabs
 {
+    /// <summary>
+    /// This <inheritdoc cref="ITab"/> implementation defines <seealso cref="GetValue"/> and <seealso cref="SetValue"/> implementation with delegates through the constructor.
+    /// </summary>
     internal class DynamicTab : ITab
     {
         public GUIContent Label { get; }
@@ -20,6 +23,9 @@ namespace Innoactive.Creator.Core.Tabs
         private readonly Func<object> getter;
         private readonly Action<object> setter;
 
+        /// <param name="label">A label to display.</param>
+        /// <param name="getter"><seealso cref="GetValue"/> implementation.</param>
+        /// <param name="setter"><seealso cref="SetValue"/> implementation.</param>
         public DynamicTab(GUIContent label, Func<object> getter, Action<object> setter)
         {
             Label = label;

--- a/Runtime/Tabs/DynamicTab.cs.meta
+++ b/Runtime/Tabs/DynamicTab.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9ac60572cf684268a89d392aee4adb0b
+timeCreated: 1593119223

--- a/Runtime/Tabs/ITab.cs
+++ b/Runtime/Tabs/ITab.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+namespace Innoactive.Creator.Core.Tabs
+{
+    internal interface ITab
+    {
+        GUIContent Label { get; }
+        object GetValue();
+        void SetValue(object value);
+    }
+}

--- a/Runtime/Tabs/ITab.cs
+++ b/Runtime/Tabs/ITab.cs
@@ -2,10 +2,24 @@ using UnityEngine;
 
 namespace Innoactive.Creator.Core.Tabs
 {
+    /// <summary>
+    /// A tab in the <seealso cref="ITabsGroup"/>
+    /// </summary>
     internal interface ITab
     {
+        /// <summary>
+        /// A label to display in the tab view.
+        /// </summary>
         GUIContent Label { get; }
+
+        /// <summary>
+        /// When user selects this tab, the Step Inspector displays the value from this method.
+        /// </summary>
         object GetValue();
+
+        /// <summary>
+        /// When user has modified the object under this tab, the Step Inspector invokes this method. It should assign the new value to the actual property.
+        /// </summary>
         void SetValue(object value);
     }
 }

--- a/Runtime/Tabs/ITab.cs.meta
+++ b/Runtime/Tabs/ITab.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d66f5f440de049338f49cccb90cb9091
+timeCreated: 1593119217

--- a/Runtime/Tabs/ITabsGroup.cs
+++ b/Runtime/Tabs/ITabsGroup.cs
@@ -3,10 +3,20 @@ using System.Runtime.Serialization;
 
 namespace Innoactive.Creator.Core.Tabs
 {
+    /// <summary>
+    /// Draws a view with multiple tabs.
+    /// </summary>
     internal interface ITabsGroup
     {
+        /// <summary>
+        /// Index of the currently selected tab.
+        /// </summary>
         [DataMember]
         int Selected { get; set; }
+
+        /// <summary>
+        /// Tabs to display. See <seealso cref="ITab"/>.
+        /// </summary>
         IList<ITab> Tabs { get; }
     }
 }

--- a/Runtime/Tabs/ITabsGroup.cs
+++ b/Runtime/Tabs/ITabsGroup.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Innoactive.Creator.Core.Tabs
+{
+    internal interface ITabsGroup
+    {
+        [DataMember]
+        int Selected { get; set; }
+        IList<ITab> Tabs { get; }
+    }
+}

--- a/Runtime/Tabs/ITabsGroup.cs.meta
+++ b/Runtime/Tabs/ITabsGroup.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e75e3455f80b469a87c2c47075c77050
+timeCreated: 1593119212

--- a/Runtime/Tabs/TabsGroup.cs
+++ b/Runtime/Tabs/TabsGroup.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Innoactive.Creator.Core.Tabs
+{
+    [DataContract]
+    internal class TabsGroup : ITabsGroup
+    {
+        [DataMember]
+        public int Selected { get; set; }
+
+        public IList<ITab> Tabs { get; }
+
+        public TabsGroup(params ITab[] tabs)
+        {
+            Tabs = tabs;
+        }
+    }
+}

--- a/Runtime/Tabs/TabsGroup.cs
+++ b/Runtime/Tabs/TabsGroup.cs
@@ -3,12 +3,15 @@ using System.Runtime.Serialization;
 
 namespace Innoactive.Creator.Core.Tabs
 {
+    /// <inheritdoc cref="ITabsGroup"/>
     [DataContract]
     internal class TabsGroup : ITabsGroup
     {
+        /// <inheritdoc />
         [DataMember]
         public int Selected { get; set; }
 
+        /// <inheritdoc />
         public IList<ITab> Tabs { get; }
 
         public TabsGroup(params ITab[] tabs)

--- a/Runtime/Tabs/TabsGroup.cs.meta
+++ b/Runtime/Tabs/TabsGroup.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fa00c095588d4c20b403cdccf7caee9e
+timeCreated: 1593119228

--- a/Runtime/Transition.cs
+++ b/Runtime/Transition.cs
@@ -5,7 +5,6 @@ using Innoactive.Creator.Core.Attributes;
 using Innoactive.Creator.Core.Conditions;
 using Innoactive.Creator.Core.Configuration.Modes;
 using Innoactive.Creator.Core.EntityOwners;
-using Innoactive.Creator.Core.Properties;
 using Innoactive.Creator.Core.RestrictiveEnvironment;
 using Innoactive.Creator.Core.Utils.Logging;
 using Innoactive.Creator.Unity;
@@ -27,7 +26,7 @@ namespace Innoactive.Creator.Core
         {
             ///<inheritdoc />
             [DataMember]
-            [DisplayName("Conditions"), Foldable, Separated, ListOf(typeof(FoldableAttribute), typeof(DeletableAttribute), typeof(SeparatedAttribute)), ExtendableList]
+            [DisplayName("Conditions"), Foldable, ListOf(typeof(FoldableAttribute), typeof(DeletableAttribute)), ExtendableList]
             public IList<ICondition> Conditions { get; set; }
 
             ///<inheritdoc />

--- a/Runtime/TransitionCollection.cs
+++ b/Runtime/TransitionCollection.cs
@@ -23,7 +23,7 @@ namespace Innoactive.Creator.Core
         {
             ///<inheritdoc />
             [DataMember]
-            [DisplayName("Transitions"), KeepPopulated(typeof(Transition)), ListOf(typeof(FoldableAttribute), typeof(DeletableAttribute), typeof(SeparatedAttribute)), ExtendableList]
+            [DisplayName(""), KeepPopulated(typeof(Transition)), ListOf(typeof(FoldableAttribute), typeof(DeletableAttribute)), ExtendableList]
             public virtual IList<ITransition> Transitions { get; set; }
 
             ///<inheritdoc />

--- a/Runtime/TransitionCollection.cs
+++ b/Runtime/TransitionCollection.cs
@@ -23,7 +23,7 @@ namespace Innoactive.Creator.Core
         {
             ///<inheritdoc />
             [DataMember]
-            [DisplayName("Transitions"), Separated, Foldable, KeepPopulated(typeof(Transition)), ListOf(typeof(FoldableAttribute), typeof(DeletableAttribute), typeof(SeparatedAttribute)), ExtendableList]
+            [DisplayName("Transitions"), KeepPopulated(typeof(Transition)), ListOf(typeof(FoldableAttribute), typeof(DeletableAttribute), typeof(SeparatedAttribute)), ExtendableList]
             public virtual IList<ITransition> Transitions { get; set; }
 
             ///<inheritdoc />

--- a/Runtime/Unity/SceneUtils.cs
+++ b/Runtime/Unity/SceneUtils.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using System.Collections.Generic;
-using Innoactive.Creator.Core.Configuration;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 

--- a/Runtime/Utils/Audio/ResourceAudio.cs
+++ b/Runtime/Utils/Audio/ResourceAudio.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.Serialization;
 using Innoactive.Creator.Core.Attributes;
 using Innoactive.Creator.Core.Internationalization;


### PR DESCRIPTION
### Description

Splits behaviors and transitions in two tabs in the Step Inspector.

### Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

### How Has This Been Tested?

I clicked around and it seems to Undo/Redo properly, save to file properly, and, of course, still allows you to modify your behaviors and transitions.

### Checklist

- [X] My code follows the [Coding Conventions](#coding-conventions)
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas - **everything is internal**
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes - **DisableGameObjectBehavior.GameObjectIsDisabledAfterActivation times out, I don't think this is because of my changes.**
- [X] Any dependent changes have been merged and published in downstream modules - **This change does not influence any other repo.**