### PR TITLE
chore: allowed menu items hide obsoleted behaviors & conditions by default

### DIFF
--- a/Editor/Configuration/AllowedMenuItemsSettings.cs
+++ b/Editor/Configuration/AllowedMenuItemsSettings.cs
@@ -209,8 +209,7 @@ namespace Innoactive.CreatorEditor.Configuration
                 {
                     continue;
                 }
-
-                SerializedBehaviorSelections.Add(type.AssemblyQualifiedName, true);
+                SerializedBehaviorSelections.Add(type.AssemblyQualifiedName, ShouldBeEnabled(type));
             }
 
             IEnumerable<Type> implementedConditions = ReflectionUtils.GetConcreteImplementationsOf<MenuItem<ICondition>>();
@@ -222,8 +221,19 @@ namespace Innoactive.CreatorEditor.Configuration
                     continue;
                 }
 
-                SerializedConditionSelections.Add(type.AssemblyQualifiedName, true);
+                SerializedConditionSelections.Add(type.AssemblyQualifiedName, ShouldBeEnabled(type));
             }
+        }
+
+        private bool ShouldBeEnabled(Type type)
+        {
+            object instance = Activator.CreateInstance(type);
+            if (instance is IInternalTypeProvider typeProvider)
+            {
+                return typeProvider.GetItemType().GetAttribute<ObsoleteAttribute>() == null;
+            }
+
+            return true;
         }
     }
 }

--- a/Editor/UI/StepInspector/Menu/IInternalTypeProvider.cs
+++ b/Editor/UI/StepInspector/Menu/IInternalTypeProvider.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Innoactive.CreatorEditor.UI.StepInspector.Menu
+{
+    /// <summary>
+    /// This is a helper for generic typed class to be able to get the internal items type.
+    /// </summary>
+    internal interface IInternalTypeProvider
+    {
+        Type GetItemType();
+    }
+}

--- a/Editor/UI/StepInspector/Menu/IInternalTypeProvider.cs.meta
+++ b/Editor/UI/StepInspector/Menu/IInternalTypeProvider.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8f83e1b8285c453486c3bb2ddca52c76
+timeCreated: 1593682382

--- a/Editor/UI/StepInspector/Menu/MenuItem.cs
+++ b/Editor/UI/StepInspector/Menu/MenuItem.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Innoactive.CreatorEditor.UI.StepInspector.Menu
 {
     /// <summary>
@@ -7,7 +9,7 @@ namespace Innoactive.CreatorEditor.UI.StepInspector.Menu
     /// If clicked, it will use the result of <see cref="GetNewItem"/>.
     /// </summary>
     /// <typeparam name="T">A type of an object to create.</typeparam>
-    public abstract class MenuItem<T> : MenuOption<T>
+    public abstract class MenuItem<T> : MenuOption<T>, IInternalTypeProvider
     {
         /// <summary>
         /// Returns a new instance of an object (behavior or condition).
@@ -18,5 +20,13 @@ namespace Innoactive.CreatorEditor.UI.StepInspector.Menu
         /// A name displayed in the Step Inspector.
         /// </summary>
         public abstract string DisplayedName { get; }
+
+        /// <summary>
+        /// Returns the Type of the item created in <see cref="GetNewItem"/>
+        /// </summary>
+        public virtual Type GetItemType()
+        {
+            return GetNewItem().GetType();
+        }
     }
 }


### PR DESCRIPTION
### Description
Obsoleted Behaviors & Conditions wont show up in default "Add Behavior/Condition" menu.