### PR TITLE
feat: locking will now also find the next chapters first step

### DIFF
--- a/Runtime/LockableObjectsCollection.cs
+++ b/Runtime/LockableObjectsCollection.cs
@@ -25,7 +25,7 @@ namespace Innoactive.Creator.Core
 
         public LockableObjectsCollection(Step.EntityData entityData)
         {
-            toUnlock = PropertyReflectionHelper.ExtractLockablesFromStep(entityData).ToList();
+            toUnlock = PropertyReflectionHelper.ExtractLockablePropertiesFromStep(entityData).ToList();
             data = entityData;
 
             CreateSceneObjects();

--- a/Runtime/Properties/PropertyReflectionHelper.cs
+++ b/Runtime/Properties/PropertyReflectionHelper.cs
@@ -18,9 +18,15 @@ namespace Innoactive.Creator.Core
     /// </summary>
     internal static class PropertyReflectionHelper
     {
-        public static List<LockablePropertyData> ExtractLockablesFromStep(IStepData data)
+        public static List<LockablePropertyData> ExtractLockablePropertiesFromStep(IStepData data)
         {
+
             List<LockablePropertyData> result = new List<LockablePropertyData>();
+
+            if (data == null)
+            {
+                return result;
+            }
 
             foreach (ITransition transition in data.Transitions.Data.Transitions)
             {


### PR DESCRIPTION
### Description
* Added a not so nice way to get the next step, if the current step is at the end of a chapter. Which is done by crawling the whole course data tree.
* Renamed ExtractLockablesFromStep to ExtractLockableFromStep
