### PR TITLE
docu: fixed typo in table of content

### DIFF
--- a/.Documentation/articles/toc.yml
+++ b/.Documentation/articles/toc.yml
@@ -68,7 +68,7 @@
       href: developer/08-conditions.md
     - name: Properties
       href: developer/09-properties.md
-    - name: Lockable Propertiees
+    - name: Lockable Properties
       href: developer/10-lockable-properties.md
     - name: Text-To-Speech
       href: developer/11-text-to-speech.md


### PR DESCRIPTION
### Description
Fixed typo in table of contents: from propertiees to properties.