### PR TITLE
feat: behaviors, transitions, and conditions are reorderable

### DIFF
--- a/Editor/UI/Drawers/Metadata.meta
+++ b/Editor/UI/Drawers/Metadata.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 25ffe1bae2e14488906f2f26d001edbd
+timeCreated: 1595335023

--- a/Editor/UI/Drawers/Metadata/ReorderableElementMetadata.cs
+++ b/Editor/UI/Drawers/Metadata/ReorderableElementMetadata.cs
@@ -1,0 +1,28 @@
+namespace Innoactive.CreatorEditor.UI.Drawers.Metadata
+{
+    /// <summary>
+    /// Metadata to make <see cref="Innoactive.Creator.Core.Attributes.ReorderableListOfAttribute"/> reorderable.
+    /// </summary>
+    public class ReorderableElementMetadata
+    {
+        /// <summary>
+        /// Determines, whether the entity must be moved up in the list.
+        /// </summary>
+        public bool MoveUp { get; set; }
+
+        /// <summary>
+        /// Determines, whether the entity must be moved down in the list.
+        /// </summary>
+        public bool MoveDown { get; set; }
+
+        /// <summary>
+        /// Determines, whether the entity is the first one in the list.
+        /// </summary>
+        public bool IsFirst { get; set; }
+
+        /// <summary>
+        /// Determines, whether the entity is the last one in the list.
+        /// </summary>
+        public bool IsLast { get; set; }
+    }
+}

--- a/Editor/UI/Drawers/Metadata/ReorderableElementMetadata.cs.meta
+++ b/Editor/UI/Drawers/Metadata/ReorderableElementMetadata.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1996edf18da74c77b6a5c187f3b1d327
+timeCreated: 1595335046

--- a/Editor/UI/Drawers/ObjectDrawer.cs
+++ b/Editor/UI/Drawers/ObjectDrawer.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Innoactive.Creator.Core;
 using Innoactive.Creator.Core.Attributes;
 using Innoactive.Creator.Core.Utils;
 using UnityEditor;
@@ -89,17 +88,17 @@ namespace Innoactive.CreatorEditor.UI.Drawers
 
         private float CreateAndDrawMetadataWrapper(Rect rect, object ownerObject, MemberInfo drawnMemberInfo, Action<object> changeValueCallback)
         {
-            PropertyInfo metadataProperty = ownerObject.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).FirstOrDefault(property => typeof(Metadata).IsAssignableFrom(property.PropertyType));
-            FieldInfo metadataField = ownerObject.GetType().GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).FirstOrDefault(field => typeof(Metadata).IsAssignableFrom(field.FieldType));
-            Metadata ownerObjectMetadata = null;
+            PropertyInfo metadataProperty = ownerObject.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).FirstOrDefault(property => typeof(Creator.Core.Metadata).IsAssignableFrom(property.PropertyType));
+            FieldInfo metadataField = ownerObject.GetType().GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).FirstOrDefault(field => typeof(Creator.Core.Metadata).IsAssignableFrom(field.FieldType));
+            Creator.Core.Metadata ownerObjectMetadata = null;
 
             if (metadataProperty != null)
             {
-                ownerObjectMetadata = (Metadata)metadataProperty.GetValue(ownerObject, null) ?? new Metadata();
+                ownerObjectMetadata = (Creator.Core.Metadata)metadataProperty.GetValue(ownerObject, null) ?? new Creator.Core.Metadata();
             }
             else if (metadataField != null)
             {
-                ownerObjectMetadata = (Metadata)metadataField.GetValue(ownerObject) ?? new Metadata();
+                ownerObjectMetadata = (Creator.Core.Metadata)metadataField.GetValue(ownerObject) ?? new Creator.Core.Metadata();
             }
             else
             {

--- a/Runtime/Attributes/ReorderableListOfAttribute.cs
+++ b/Runtime/Attributes/ReorderableListOfAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Innoactive.Creator.Core.Attributes
+{
+    /// <summary>
+    /// Declares that children of this list have metadata attributes and can be reordered.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public class ReorderableListOfAttribute : ListOfAttribute
+    {
+        /// <inheritdoc />
+        public ReorderableListOfAttribute(params Type[] childAttributes) : base(childAttributes) { }
+    }
+}

--- a/Runtime/Attributes/ReorderableListOfAttribute.cs.meta
+++ b/Runtime/Attributes/ReorderableListOfAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 58397c73c01eed3458f60626ab3df510
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/BehaviorCollection.cs
+++ b/Runtime/BehaviorCollection.cs
@@ -25,7 +25,7 @@ namespace Innoactive.Creator.Core
             /// List of all <see cref="IBehavior"/>s added.
             /// </summary>
             [DataMember]
-            [DisplayName(""), ListOf(typeof(FoldableAttribute), typeof(DeletableAttribute), typeof(DrawIsBlockingToggleAttribute)), ExtendableList]
+            [DisplayName(""), ReorderableListOf(typeof(FoldableAttribute), typeof(DeletableAttribute), typeof(DrawIsBlockingToggleAttribute)), ExtendableList]
             public virtual IList<IBehavior> Behaviors { get; set; }
 
             /// <summary>

--- a/Runtime/Transition.cs
+++ b/Runtime/Transition.cs
@@ -26,7 +26,7 @@ namespace Innoactive.Creator.Core
         {
             ///<inheritdoc />
             [DataMember]
-            [DisplayName("Conditions"), Foldable, ListOf(typeof(FoldableAttribute), typeof(DeletableAttribute)), ExtendableList]
+            [DisplayName("Conditions"), Foldable, ReorderableListOf(typeof(FoldableAttribute), typeof(DeletableAttribute)), ExtendableList]
             public IList<ICondition> Conditions { get; set; }
 
             ///<inheritdoc />

--- a/Runtime/TransitionCollection.cs
+++ b/Runtime/TransitionCollection.cs
@@ -23,7 +23,7 @@ namespace Innoactive.Creator.Core
         {
             ///<inheritdoc />
             [DataMember]
-            [DisplayName(""), KeepPopulated(typeof(Transition)), ListOf(typeof(FoldableAttribute), typeof(DeletableAttribute)), ExtendableList]
+            [DisplayName(""), KeepPopulated(typeof(Transition)), ReorderableListOf(typeof(FoldableAttribute), typeof(DeletableAttribute)), ExtendableList]
             public virtual IList<ITransition> Transitions { get; set; }
 
             ///<inheritdoc />


### PR DESCRIPTION
### Description
In the Step Inspector all behaviors, transitions, and conditions are reorderable now. They can be moved up and down. Therefore, a new 'ReorderableListOfAttribute' attribute is introduced.

**Fixes**: [TRNG-495](https://jira.innoactive.de/browse/TRNG-495)

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### How Has This Been Tested?
This was tested manually, since it's a UI change.


**Test Configuration**: Home PC, Unity 2019.4.1f1 LTS

### Checklist
<!--- Make sure your PR meets the following criteria before opening it. -->

- [x] My code follows the [Coding Conventions](#coding-conventions)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - **currently on it**
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules