### PR TITLE
fix: update obsolete metadata properly

### DIFF
--- a/Editor/UI/Drawers/ObjectDrawer.cs
+++ b/Editor/UI/Drawers/ObjectDrawer.cs
@@ -124,6 +124,7 @@ namespace Innoactive.CreatorEditor.UI.Drawers
                     wrapper.Metadata[key] = newWrapper.Metadata[key];
                 }
 
+                ownerObjectMetadata.Clear();
                 foreach (string key in newWrapper.Metadata.Keys)
                 {
                     ownerObjectMetadata.SetMetadata(drawnMemberInfo, key, newWrapper.Metadata[key]);

--- a/Runtime/Attributes/ListOfAttribute.cs
+++ b/Runtime/Attributes/ListOfAttribute.cs
@@ -74,7 +74,28 @@ namespace Innoactive.Creator.Core.Attributes
                 return false;
             }
 
-            return listOfMetadata.ChildMetadata.All(entryMetadata => listOfMetadata.ChildAttributes.All(childAttribute => childAttributes.Any(attribute => attribute.Name == childAttribute.Name) && entryMetadata.ContainsKey(childAttribute.Name) && childAttribute.IsMetadataValid(entryMetadata[childAttribute.Name])));
+            foreach (Dictionary<string, object> entryMetadata in listOfMetadata.ChildMetadata)
+            {
+                foreach (MetadataAttribute childAttribute in listOfMetadata.ChildAttributes)
+                {
+                    if (childAttributes.Any(attribute => attribute.Name == childAttribute.Name) == false)
+                    {
+                        return false;
+                    }
+
+                    if (entryMetadata.ContainsKey(childAttribute.Name) == false)
+                    {
+                        return false;
+                    }
+
+                    if (childAttribute.IsMetadataValid(entryMetadata[childAttribute.Name]) == false)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
         }
 
         private static bool AreSetsTheSame<T>(IEnumerable<T> first, IEnumerable<T> second, Func<T, IComparable> toComparable)

--- a/Runtime/Metadata.cs
+++ b/Runtime/Metadata.cs
@@ -56,5 +56,10 @@ namespace Innoactive.Creator.Core
 
             return new Dictionary<string, object>();
         }
+
+        public void Clear()
+        {
+            values = new Dictionary<string, Dictionary<string, object>>();
+        }
     }
 }


### PR DESCRIPTION
### Description

This fixes the bug when you can't drag transitions if you have the transition view open for a step that was created before v2.1.

**Fixes**: #948

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I clicked around to see if it fixes the issue or breaks something else. More of clicking around is required.


### Checklist

- [X] My code follows the [Coding Conventions](#coding-conventions)
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (N/A)