### PR TITLE
docs: step inspector article is updated

### DIFF
--- a/.Documentation/articles/images/step-inspector/add-behavior.gif
+++ b/.Documentation/articles/images/step-inspector/add-behavior.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:37e38a569f98dfc8871168f0245a8cbe64783c059a67bb10ee70bf23f4a13fe1
-size 168271
+oid sha256:b5ff672e1a3a781af79bae2b1cba0366acd35be89cec13821eec41bd67c9adaa
+size 153713

--- a/.Documentation/articles/images/step-inspector/add-condition.gif
+++ b/.Documentation/articles/images/step-inspector/add-condition.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:66cc661ebc17faabefed0427eed5b4807f72c219a15d9e0f5f52300252477e38
-size 163542
+oid sha256:d5fd52ba34bf8d9807593c24f1fa32b0a70eed74edf456a4cb10755c3130fd78
+size 163609

--- a/.Documentation/articles/images/step-inspector/add-transition.gif
+++ b/.Documentation/articles/images/step-inspector/add-transition.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4d291c18cb1c9c5e8912ea5d0415ac204ffb1d28739d2595c2324c7abea9573
-size 224580
+oid sha256:f6f1d86e2a6bf707533764caeb248b5c1505ef0a0059b4bca8ffdd3131f8c090
+size 269386

--- a/.Documentation/articles/images/step-inspector/change-description.gif
+++ b/.Documentation/articles/images/step-inspector/change-description.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bfbbf665c18ae925553f3e92ac33d7ca77c1ca63d12ddd2530a29835aefa52bc
-size 73673
+oid sha256:52e6f66a413b83aebcc0fa122ecfbc02358916c0d75e72aa514bf1d32137fc9f
+size 71727

--- a/.Documentation/articles/images/step-inspector/icon_arrow_down_dark.png
+++ b/.Documentation/articles/images/step-inspector/icon_arrow_down_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4367287bbc26e1c3c768b5a31bb3e4724552eb5ad6cf28a7fb1acc14e00e79f6
+size 643

--- a/.Documentation/articles/images/step-inspector/icon_arrow_up_dark.png
+++ b/.Documentation/articles/images/step-inspector/icon_arrow_up_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:389e8e6f4da80fea9a20cbc7aea79a52d35acac8cbb8f14f509f33db24455cc5
+size 619

--- a/.Documentation/articles/images/step-inspector/icon_delete_dark.png
+++ b/.Documentation/articles/images/step-inspector/icon_delete_dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27c20bd8b153b9676b7e4e424769d3cb566e9ebdcd8c2c7b49d4899ca9c0958f
+size 363

--- a/.Documentation/articles/images/step-inspector/open-inspector.gif
+++ b/.Documentation/articles/images/step-inspector/open-inspector.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:614868c727da40e2fe38291500ddc0aa58f49503a1410de8492b0f28bec292e1
-size 58083
+oid sha256:84547483ee88f823124aaa64d19718760bb44b8040a29dcc42fdf38ccd7a272a
+size 52845

--- a/.Documentation/articles/images/step-inspector/rename-step.gif
+++ b/.Documentation/articles/images/step-inspector/rename-step.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7d154f01d8f6bc9204af13f75582a78d82498652e7071a528dd8c955edb3d971
-size 70278
+oid sha256:82ec214a2629af0747aee526c8d87d6be1f0a23dfa37a45c21222f1c4103631f
+size 67298

--- a/.Documentation/articles/images/step-inspector/reorder-entities.gif
+++ b/.Documentation/articles/images/step-inspector/reorder-entities.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:402407c81e2f4b8b371bdeb7670a34ba0a9ebb1fe9d600cac712100136806c24
+size 216614

--- a/.Documentation/articles/images/step-inspector/unlock-objects.gif
+++ b/.Documentation/articles/images/step-inspector/unlock-objects.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2419e4918d4c2e564117ca3a253b48da67da206c351ba8cb8a069ccdd5b9a08
+size 146044

--- a/.Documentation/articles/innoactive-creator/step-inspector.md
+++ b/.Documentation/articles/innoactive-creator/step-inspector.md
@@ -26,23 +26,39 @@ To change the description of a step, click on the step in the [Workflow Editor](
 
 ## Add and Remove Behaviors
 
-To add a behavior, click on the `Add Behavior` button in the Step Inspector. To remove one, click on the `X` button in the upper right corner of it.
+To add a behavior, click on the `Behaviors` tab and the `Add Behavior` button in the Step Inspector. To remove one, click on the <img src="../images/step-inspector/icon_delete_dark.png" alt="Trash Can Icon" height="16px"/> button in the upper right corner of it.
 
-> Learn more about the [default behaviors](default-behaviors.md).
+Learn more about the [default behaviors](default-behaviors.md).
 
 [![Add a behavior to a step](../images/step-inspector/add-behavior.gif "How to add a behavior to a step.")](../images/step-inspector/add-behavior.gif)
 
+## Add and Remove Transitions
+
+To add a transition in the Step Inspector, click on the `Transitions` tab and the `Add Transition` button. It will point to the end of the chapter by default. To choose another destination, see [the article about Workflow Editor](workflow-editor.md#add-transitions).  
+You can remove a transition by clicking on the <img src="../images/step-inspector/icon_delete_dark.png" alt="Trash Can Icon" height="16px"/> button in the upper right corner of it.
+
+[![Add a transition to a step](../images/step-inspector/add-transition.gif "How to add a transition to a step.")](../images/step-inspector/add-transition.gif)
+
 ## Add and Remove Conditions
 
-To add a condition, find the transition you want to add it to in the Step Inspector, and click on the `Add Condition` button. To remove a condition, click on the `X` button in the upper right corner of it.
+To add a condition, click on the `Transitions` tab in the Step Inspector, find the transition you want to add it to, and click on the `Add Condition` button. To remove a condition, click on the <img src="../images/step-inspector/icon_delete_dark.png" alt="Trash Can Icon" height="16px"/> button in the upper right corner of it.
 
-> Learn more about the [default conditions](default-conditions.md).
+Learn more about the [default conditions](default-conditions.md).
 
 [![Add a condition to a step](../images/step-inspector/add-condition.gif "How to add a condition to a step.")](../images/step-inspector/add-condition.gif)
 
-## Add and Remove Transitions
+## Reorder Behaviors, Transitions, and Conditions
 
-To add a transition in the Step Inspector, click on the `Add Transition` button. It will point to the end of the chapter by default. To choose another destination, see [the article about Workflow Editor](workflow-editor.md#add-transitions).  
-You can remove a transition by clicking on the `X` button in the upper right corner of it.
+To reorder a behavior, transition, or condition, click on the <img src="../images/step-inspector/icon_arrow_down_dark.png" alt="Arrow Down Icon" height="16px"/> button to move it down or on the <img src="../images/step-inspector/icon_arrow_up_dark.png" alt="Arrow Up Icon" height="16px"/> button to move it up.
 
-[![Add a transition to a step](../images/step-inspector/add-transition.gif "How to add a transition to a step.")](../images/step-inspector/add-transition.gif)
+Tip: You can change the priority of transitions by sorting them from top to bottom. If two or more transitions are completed at the same time, the highest one in the list will be prioritized.
+
+[![Reorder transitions](../images/step-inspector/reorder-entities.gif "How to reorder behaviors, transitions, and conditions.")](../images/step-inspector/reorder-entities.gif)
+
+## Unlock Objects in Current Step
+
+By default, every property (Touching, Grabbing, Using, ...) on a training scene object that is not needed by a condition is locked (non-interactable) during a step. In the `Unlocked Objects` tab you can see which object properties are active and which are not. You can also manually drag in other training scene objects from the scene to manually unlock their properties per step.
+
+Learn more about [Training Scene Objects and their properties](training-scene-object.md).
+
+[![Unlock Objects](../images/step-inspector/unlock-objects.gif "How to unlock Training Scene Objects.")](../images/step-inspector/unlock-objects.gif)


### PR DESCRIPTION
### Description
The Step Inspector article of our documentation is now updated.
New images (gifs and pngs) and descriptions for reordering and unlocking objects are added.

**Fixes**: # [TRNG-495](https://jira.innoactive.de/browse/TRNG-495)

### Type of change

- [x] Documentation update

### How Has This Been Tested?
I read it.

### Checklist

- [x] My code follows the [Coding Conventions](#coding-conventions)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules