### PR TITLE
DefaultEditingStrategy now checks if StepWindow exits before calling it.

### DIFF
--- a/Editor/DefaultEditingStrategy.cs
+++ b/Editor/DefaultEditingStrategy.cs
@@ -170,7 +170,10 @@ namespace Innoactive.CreatorEditor
         /// <inheritdoc/>
         public void HandleExitingPlayMode()
         {
-            stepWindow.ResetStepView();
+            if (stepWindow != null)
+            {
+                stepWindow.ResetStepView();
+            }
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

**Fixes**: # The `DefaultEditingStrategy` reset the step window view when entering play mode or edit mode, unfortunately, it assumes that the step window is always opened, throwing an NRE when it is not. 

### Type of change
<!--- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Open a training scene, make sure the step editor is closed, play the scene, and then stop it, no need to run the course.