### PR TITLE
fix: position of line between entry node and step node

### DIFF
--- a/Editor/UI/Graphics/StepNode.cs
+++ b/Editor/UI/Graphics/StepNode.cs
@@ -88,7 +88,7 @@ namespace Innoactive.CreatorEditor.UI.Graphics
             Step = step;
             renderer = new StepNodeRenderer(this, graphics.ColorPalette);
 
-            EntryJoints.Add(new EntryJoint(graphics, this) { RelativePosition = new Vector2(-size.x / 2f, 0f) });
+            EntryJoints.Add(new EntryJoint(graphics, this) { RelativePosition = new Vector2(-size.x / 2f, -1f) });
 
             CreateTransitionButton = new CreateTransitionButton(graphics, this) { RelativePosition = new Vector2(size.x / 2f, 0) };
         }


### PR DESCRIPTION
### Description
Position between EntryNode and StepNode on the same y-Level is off by one pixel. Fixed by moving the EntryJoint of the StepNode up by one pixel because it was off.

Fixes: https://jira.innoactive.de/browse/TRNG-946

Previous:
![image](https://user-images.githubusercontent.com/3699271/89196608-bb321680-d5aa-11ea-94e3-f6dc8623252f.png)

Now:
![image](https://user-images.githubusercontent.com/3699271/89196754-f03e6900-d5aa-11ea-8bdd-d6521c9f9e0e.png)

