### PR TITLE
feature: make it possible to add tooltips.

### DIFF
--- a/Editor/UI/Drawers/AbstractDrawer.cs
+++ b/Editor/UI/Drawers/AbstractDrawer.cs
@@ -15,6 +15,7 @@ namespace Innoactive.CreatorEditor.UI.Drawers
     public abstract class AbstractDrawer : ITrainingDrawer
     {
         /// <inheritdoc />
+        [Obsolete("Use the overload with GUIContent label instead.")]
         public Rect Draw(Rect rect, object currentValue, Action<object> changeValueCallback, string label)
         {
             return Draw(rect, currentValue, changeValueCallback, new GUIContent(label));

--- a/Editor/UI/Drawers/ITrainingDrawer.cs
+++ b/Editor/UI/Drawers/ITrainingDrawer.cs
@@ -12,6 +12,7 @@ namespace Innoactive.CreatorEditor.UI.Drawers
         /// <summary>
         /// Draw editor view in given Rect.
         /// </summary>
+        /// Obsolete. Use the overload with GUIContent label instead.
         /// <param name="rect">A rectangle in which editor view should fit. The height value is ignored.</param>
         /// <param name="currentValue">Current value of a member.</param>
         /// <param name="changeValueCallback">
@@ -20,6 +21,7 @@ namespace Innoactive.CreatorEditor.UI.Drawers
         /// </param>
         /// <param name="label">Label text to display.</param>
         /// <returns>The area that was taken by the property.</returns>
+        [Obsolete("Use the overload with GUIContent label instead.")]
         Rect Draw(Rect rect, object currentValue, Action<object> changeValueCallback, string label);
 
         /// <summary>

--- a/Editor/UI/Drawers/ListDrawer.cs
+++ b/Editor/UI/Drawers/ListDrawer.cs
@@ -31,7 +31,7 @@ namespace Innoactive.CreatorEditor.UI.Drawers
 
             if (label != null && label != GUIContent.none && (label.image != null || string.IsNullOrEmpty(label.text) == false))
             {
-                EditorGUI.LabelField(new Rect(rect.x, currentY, rect.width, EditorDrawingHelper.HeaderLineHeight), label, labelStyle);
+                EditorGUI.LabelField(new Rect(rect.x, currentY, labelStyle.CalcSize(label).x, EditorDrawingHelper.HeaderLineHeight), label, labelStyle);
                 currentY += EditorDrawingHelper.HeaderLineHeight;
             }
 

--- a/Editor/UI/Drawers/MetadataWrapperDrawer.cs
+++ b/Editor/UI/Drawers/MetadataWrapperDrawer.cs
@@ -9,7 +9,7 @@ using Innoactive.Creator.Core.UI.Drawers.Metadata;
 using Innoactive.Creator.Core.Utils;
 using UnityEditor;
 using UnityEngine;
-
+using TooltipAttribute = Innoactive.Creator.Core.Attributes.TooltipAttribute;
 namespace Innoactive.CreatorEditor.UI.Drawers
 {
     /// <summary>
@@ -20,6 +20,7 @@ namespace Innoactive.CreatorEditor.UI.Drawers
     [DefaultTrainingDrawer(typeof(MetadataWrapper))]
     internal class MetadataWrapperDrawer : AbstractDrawer
     {
+        private readonly string tooltipName = typeof(TooltipAttribute).FullName;
         private readonly string reorderableName = "ReorderableElement";
         private readonly string separatedName = typeof(SeparatedAttribute).FullName;
         private readonly string deletableName = typeof(DeletableAttribute).FullName;
@@ -38,6 +39,11 @@ namespace Innoactive.CreatorEditor.UI.Drawers
         public override Rect Draw(Rect rect, object currentValue, Action<object> changeValueCallback, GUIContent label)
         {
             MetadataWrapper wrapper = (MetadataWrapper)currentValue;
+
+            if (wrapper.Metadata.ContainsKey(tooltipName))
+            {
+                return DrawTooltip(rect, wrapper, changeValueCallback, label);
+            }
 
             if (wrapper.Metadata.ContainsKey(reorderableName))
             {
@@ -101,6 +107,12 @@ namespace Innoactive.CreatorEditor.UI.Drawers
             ITrainingDrawer valueDrawer = DrawerLocator.GetDrawerForValue(wrapper.Value, wrapper.ValueDeclaredType);
 
             return valueDrawer.GetLabel(wrapper.Value, wrapper.ValueDeclaredType);
+        }
+
+        private Rect DrawTooltip(Rect rect, MetadataWrapper wrapper, Action<object> changeValueCallback, GUIContent label)
+        {
+            label.tooltip = wrapper.Metadata[tooltipName].ToString();
+            return DrawRecursively(rect, wrapper, tooltipName, changeValueCallback, label);
         }
 
         private Rect DrawReorderable(Rect rect, MetadataWrapper wrapper, Action<object> changeValueCallback, GUIContent label)
@@ -278,7 +290,7 @@ namespace Innoactive.CreatorEditor.UI.Drawers
             {
                 backgroundBehaviorData.IsBlocking = (bool)newValue;
                 changeValueCallback(wrapper);
-            }, "Is blocking").height;
+            }, new GUIContent("Is blocking")).height;
 
             return rect;
         }
@@ -325,7 +337,7 @@ namespace Innoactive.CreatorEditor.UI.Drawers
 
                     wrapper.Value = list;
                     changeValueCallback(wrapper);
-                }, "").height;
+                }, GUIContent.none).height;
             }
 
             rect.height = currentY;

--- a/Editor/UI/Drawers/NameableDrawer.cs
+++ b/Editor/UI/Drawers/NameableDrawer.cs
@@ -19,9 +19,6 @@ namespace Innoactive.CreatorEditor.UI.Drawers
 
             Rect nameRect = rect;
             nameRect.width = EditorGUIUtility.labelWidth;
-            Rect typeRect = rect;
-            typeRect.x += EditorGUIUtility.labelWidth;
-            typeRect.width -= EditorGUIUtility.labelWidth;
 
             GUIStyle textFieldStyle = new GUIStyle(EditorStyles.textField)
             {
@@ -38,7 +35,13 @@ namespace Innoactive.CreatorEditor.UI.Drawers
                 padding = new RectOffset(4, 0, 0, 0)
             };
 
-            EditorGUI.LabelField(typeRect, GetTypeNameLabel(nameable, nameable.GetType()), labelStyle);
+            GUIContent typeLabel = GetTypeNameLabel(nameable, nameable.GetType());
+
+            Rect typeRect = rect;
+            typeRect.x += EditorGUIUtility.labelWidth;
+            typeRect.width = labelStyle.CalcSize(typeLabel).x;
+
+            EditorGUI.LabelField(typeRect, typeLabel, labelStyle);
 
             if (newName != nameable.Name)
             {

--- a/Editor/UI/Windows/CourseWindow.cs
+++ b/Editor/UI/Windows/CourseWindow.cs
@@ -96,6 +96,8 @@ namespace Innoactive.CreatorEditor.UI.Windows
                 titleIcon = new EditorIcon("icon_training_editor");
             }
 
+            SetTabName();
+
             GlobalEditorHandler.CourseWindowOpened(this);
         }
 
@@ -110,8 +112,6 @@ namespace Innoactive.CreatorEditor.UI.Windows
             {
                 return;
             }
-
-            SetTabName();
 
             float width = chapterMenu.IsExtended ? TrainingMenuView.ExtendedMenuWidth : TrainingMenuView.MinimizedMenuWidth;
             Rect scrollRect = new Rect(width, 0f, position.size.x - width, position.size.y);

--- a/Editor/UI/Windows/StepWindow.cs
+++ b/Editor/UI/Windows/StepWindow.cs
@@ -72,7 +72,7 @@ namespace Innoactive.CreatorEditor.UI.Windows
             scrollPosition = GUI.BeginScrollView(new Rect(0, 0, position.width, position.height), scrollPosition, stepRect, false, false);
             {
                 Rect stepDrawingRect = new Rect(stepRect.position + new Vector2(border, border), stepRect.size - new Vector2(border * 2f, border * 2f));
-                stepDrawingRect = drawer.Draw(stepDrawingRect, step, ModifyStep, "Step");
+                stepDrawingRect = drawer.Draw(stepDrawingRect, step, ModifyStep, new GUIContent("Step"));
                 stepRect = new Rect(stepDrawingRect.position - new Vector2(border,border), stepDrawingRect.size + new Vector2(border * 2f, border * 2f));
             }
             GUI.EndScrollView();

--- a/Runtime/Attributes/TooltipAttribute.cs
+++ b/Runtime/Attributes/TooltipAttribute.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+
+namespace Innoactive.Creator.Core.Attributes
+{
+    public class TooltipAttribute : MetadataAttribute
+    {
+        private readonly string tooltip;
+
+        public TooltipAttribute(string tooltip)
+        {
+            this.tooltip = tooltip;
+        }
+
+        public override object GetDefaultMetadata(MemberInfo owner)
+        {
+            return tooltip;
+        }
+
+        public override bool IsMetadataValid(object metadata)
+        {
+            return metadata is string;
+        }
+    }
+}

--- a/Runtime/Attributes/TooltipAttribute.cs.meta
+++ b/Runtime/Attributes/TooltipAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1523822a36a74e7693aa1a57a3ecaf56
+timeCreated: 1597252107

--- a/Runtime/EntityOwners/Sequence/EntityIteratingProcess.cs
+++ b/Runtime/EntityOwners/Sequence/EntityIteratingProcess.cs
@@ -93,7 +93,7 @@ namespace Innoactive.Creator.Core.EntityOwners
                     current.LifeCycle.Deactivate();
                 }
 
-                current = default(TEntity);
+                current = default;
             }
         }
 


### PR DESCRIPTION
### Description

I have implemented tooltips by accident while working on TRNG-1005. No clue how did I end up doing it.

Add the [Tooltip(string)] attribute (not UnityEngine.TooltipAttribute) to any property or field in your IData. Hover over its label in the step inspector. Here's your tooltip.

### Type of change

- [X] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

I tested it with properties inside behavior's data, and inside the step data. It worked.

### Checklist

- [X] My code follows the [Coding Conventions](#coding-conventions)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes