### PR TITLE
Feature/open course window

### DIFF
--- a/Editor/TestTools/EditorImguiTester/Windows/EditorImguiTestsExplorer.cs
+++ b/Editor/TestTools/EditorImguiTester/Windows/EditorImguiTestsExplorer.cs
@@ -84,7 +84,7 @@ namespace Innoactive.CreatorEditor.TestTools
             };
         }
 
-        [MenuItem("Innoactive/Creator/Developer/Editor IMGUI Tests Explorer", false, 81)]
+        [MenuItem("Innoactive/Developer/Editor IMGUI Tests Explorer", false, 81)]
         private static void ShowFromMenu()
         {
             GetWindow<EditorImguiTestsExplorer>();

--- a/Editor/UI/CreatorEditorStyles.cs
+++ b/Editor/UI/CreatorEditorStyles.cs
@@ -103,6 +103,23 @@ namespace Innoactive.CreatorEditor.UI
             }
         }
 
+        private static GUIStyle radioButton;
+        public static GUIStyle RadioButton
+        {
+            get
+            {
+                if (radioButton == null)
+                {
+                    radioButton = new GUIStyle(EditorStyles.radioButton);
+                    radioButton.fontSize = Paragraph.fontSize;
+                    radioButton.padding = new RectOffset((int)(Indent + Indent * 0.75f), BaseIndent, 0, 0); // this only affects the text
+                    radioButton.margin = new RectOffset(Indent, BaseIndent, BaseIndent, BaseIndent); // this affects the position
+                }
+
+                return radioButton;
+            }
+        }
+
         private static GUIStyle subText;
         public static GUIStyle SubText
         {

--- a/Editor/UI/CreatorMenu/ImportTrainingMenuEntry.cs
+++ b/Editor/UI/CreatorMenu/ImportTrainingMenuEntry.cs
@@ -14,7 +14,7 @@ namespace Innoactive.CreatorEditor.CreatorMenu
         /// <summary>
         /// Allows to import trainings.
         /// </summary>
-        [MenuItem("Innoactive/Creator/Import Training Course", false, 14)]
+        [MenuItem("Innoactive/Import Training Course", false, 14)]
         private static void ImportTraining()
         {
             string path = EditorUtility.OpenFilePanel("Select your training", ".", String.Empty);

--- a/Editor/UI/CreatorMenu/SetupSceneEntry.cs
+++ b/Editor/UI/CreatorMenu/SetupSceneEntry.cs
@@ -8,7 +8,7 @@ namespace Innoactive.CreatorEditor.CreatorMenu
         /// <summary>
         /// Setup the current unity scene to be a functioning training scene.
         /// </summary>
-        [MenuItem("Innoactive/Creator/Setup Training Scene", false, 16)]
+        [MenuItem("Innoactive/Setup Training Scene", false, 16)]
         public static void SetupScene()
         {
             TrainingSceneSetup.Run();

--- a/Editor/UI/Windows/AllowedMenuItemsWindow.cs
+++ b/Editor/UI/Windows/AllowedMenuItemsWindow.cs
@@ -18,7 +18,7 @@ namespace Innoactive.CreatorEditor.UI.Windows
     {
         private static AllowedMenuItemsWindow window;
 
-        private const string menuPath = "Innoactive/Creator/Developer/Allowed Menu Items Configuration";
+        private const string menuPath = "Innoactive/Developer/Allowed Menu Items Configuration";
 
         private bool isEditUnlocked;
         private static IList<EntityEntry> behaviorList;

--- a/Editor/UI/Windows/CourseCreationWizard.cs
+++ b/Editor/UI/Windows/CourseCreationWizard.cs
@@ -16,7 +16,7 @@ namespace Innoactive.CreatorEditor.UI.Windows
         // CourseCreationWizard is obsolete and was replaced by CreatorSetupWizard
         // private const string menuPath = "Innoactive/Creator/Create New Course...";
 #if !UNITY_2019_4_OR_NEWER || UNITY_EDITOR_OSX
-        [MenuItem("Innoactive/Creator/Create New Course...")]
+        [MenuItem("Innoactive/Create New Course...")]
 #endif
         private static void ShowWizard()
         {

--- a/Editor/UI/Windows/OpenCourseWizard.cs
+++ b/Editor/UI/Windows/OpenCourseWizard.cs
@@ -12,13 +12,13 @@ namespace Innoactive.CreatorEditor.UI.Windows
     internal class OpenCourseWizard : EditorWindow
     {
         private static OpenCourseWizard window;
-        private const string menuPath = "Innoactive/Creator/Open Course...";
+        private const string menuPath = "Innoactive/Open Course...";
         protected EditorIcon logo;
         private string errorMessage;
 
         private int selectedCourseIndex = 0;
 
-        [MenuItem(menuPath, false, 13)]
+        [MenuItem(menuPath, false, 1)]
         private static void ShowWizard()
         {
             if (window == null)
@@ -91,7 +91,7 @@ namespace Innoactive.CreatorEditor.UI.Windows
             {
                 EditorGUI.BeginDisabledGroup(disableCourseSelection);
 
-                GUILayout.Label("Choose course to use in current scene:", CreatorEditorStyles.Paragraph);
+                GUILayout.Label("Choose training course to use in your current scene:", CreatorEditorStyles.Paragraph);
 
                 string[] courseNames = CourseAssetUtils.DoesAnyCourseExist() ? CourseAssetUtils.GetAllCourses().ToArray() : new[] {""};
                 selectedCourseIndex = EditorGUILayout.Popup(selectedCourseIndex, courseNames, CreatorEditorStyles.Popup);

--- a/Editor/UI/Windows/OpenCourseWizard.cs
+++ b/Editor/UI/Windows/OpenCourseWizard.cs
@@ -1,0 +1,118 @@
+﻿using System.Linq;
+using Innoactive.Creator.Core.Configuration;
+using Innoactive.CreatorEditor.Setup;
+using UnityEditor;
+using UnityEngine;
+
+namespace Innoactive.CreatorEditor.UI.Windows
+{
+    /// <summary>
+    /// Wizard for training course creation and management.
+    /// </summary>
+    internal class OpenCourseWizard : EditorWindow
+    {
+        private static OpenCourseWizard window;
+        private const string menuPath = "Innoactive/Creator/Open Course...";
+        protected EditorIcon logo;
+        private string errorMessage;
+
+        private int selectedCourseIndex = 0;
+
+        [MenuItem(menuPath, false, 13)]
+        private static void ShowWizard()
+        {
+            if (window == null)
+            {
+                OpenCourseWizard[] openedTrainingWizards = Resources.FindObjectsOfTypeAll<OpenCourseWizard>();
+
+                if (openedTrainingWizards.Length > 1)
+                {
+                    for (int i = 1; i < openedTrainingWizards.Length; i++)
+                    {
+                        openedTrainingWizards[i].Close();
+                    }
+
+                    Debug.LogWarning("There were more than one Open Course windows open. This should not happen. The redundant windows were closed.");
+                }
+
+                window = openedTrainingWizards.Length > 0 ? openedTrainingWizards[0] : GetWindow<OpenCourseWizard>();
+            }
+
+            window.Show();
+            window.Focus();
+        }
+
+        private void OnGUI()
+        {
+            // Magic number.
+            Vector2 windowSize = new Vector2(420f, 250f);
+            minSize = windowSize;
+            maxSize = windowSize;
+            titleContent = new GUIContent("Open Course");
+
+            Rect drawingWindow = new Rect(0f, 10f, windowSize.x, windowSize.y);
+            if (logo == null)
+            {
+                logo = new EditorIcon("logo_creator_icon");
+            }
+
+            Rect logoRect = new Rect(drawingWindow.x + drawingWindow.width * 0.25f, drawingWindow.y, drawingWindow.width * 0.5f, (drawingWindow.width * 0.34f) * 0.5f);
+            GUILayout.BeginArea(logoRect);
+                GUI.DrawTexture(new Rect(0, 0, logoRect.width, logoRect.height), logo.Texture);
+            GUILayout.EndArea();
+
+            Rect contentArea = drawingWindow;
+            contentArea.y = logoRect.height + CreatorEditorStyles.Indent * 2;
+            contentArea.height -= logoRect.height;
+
+            bool disableCourseSelection = false;
+            bool doesAnyCourseExist = CourseAssetUtils.DoesAnyCourseExist();
+            bool isSceneSetup = RuntimeConfigurator.Exists;
+
+            if (doesAnyCourseExist == false || isSceneSetup == false)
+            {
+                disableCourseSelection = true;
+                errorMessage = (doesAnyCourseExist == false)
+                    ? "There are no training courses in this Unity project. To create a course select \"Innoactive > Creator > Create New Course...\"."
+                    : "The current scene is not a training scene. No course can be created. To automatically setup the scene, select \"Innoactive > Creator > Setup Training Scene\".";
+
+                // Add offset to HelpBox Area which cannot be styled with EditorStyles
+                RectOffset offset = new RectOffset(CreatorEditorStyles.Indent, CreatorEditorStyles.Indent, 0, 0);
+                contentArea = offset.Remove(contentArea);
+                GUILayout.BeginArea(contentArea);
+                    EditorGUILayout.HelpBox(errorMessage, MessageType.Error);
+                GUILayout.EndArea();
+
+                // Reset the offset
+                contentArea = new RectOffset(CreatorEditorStyles.Indent, CreatorEditorStyles.Indent, -50, 0).Add(contentArea);
+            }
+
+            GUILayout.BeginArea(contentArea);
+            {
+                EditorGUI.BeginDisabledGroup(disableCourseSelection);
+
+                GUILayout.Label("Choose course to use in current scene:", CreatorEditorStyles.Paragraph);
+
+                string[] courseNames = CourseAssetUtils.DoesAnyCourseExist() ? CourseAssetUtils.GetAllCourses().ToArray() : new[] {""};
+                selectedCourseIndex = EditorGUILayout.Popup(selectedCourseIndex, courseNames, CreatorEditorStyles.Popup);
+
+                GUILayout.Space(CreatorEditorStyles.Indent);
+
+                GUILayout.BeginHorizontal();
+                {
+                    GUILayout.FlexibleSpace();
+                    if (GUILayout.Button("Open Course", GUILayout.Width(128), GUILayout.Height(32)))
+                    {
+                        SceneSetupUtils.SetCourseInCurrentScene(courseNames[selectedCourseIndex]);
+                    }
+
+                    GUILayout.FlexibleSpace();
+                }
+                GUILayout.EndHorizontal();
+
+                EditorGUI.EndDisabledGroup();
+            }
+            GUILayout.EndArea();
+        }
+    }
+}

--- a/Editor/UI/Windows/OpenCourseWizard.cs
+++ b/Editor/UI/Windows/OpenCourseWizard.cs
@@ -104,6 +104,7 @@ namespace Innoactive.CreatorEditor.UI.Windows
                     if (GUILayout.Button("Open Course", GUILayout.Width(128), GUILayout.Height(32)))
                     {
                         SceneSetupUtils.SetCourseInCurrentScene(courseNames[selectedCourseIndex]);
+                        Close();
                     }
 
                     GUILayout.FlexibleSpace();

--- a/Editor/UI/Windows/OpenCourseWizard.cs.meta
+++ b/Editor/UI/Windows/OpenCourseWizard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5dcc18f6bef141f458f5a819d99790e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/UI/Windows/TrackingSettingsWindow.cs
+++ b/Editor/UI/Windows/TrackingSettingsWindow.cs
@@ -7,7 +7,7 @@ namespace Innoactive.CreatorEditor.Analytics
 {
     internal class TrackingSettingsWindow : EditorWindow
     {
-        private const string menuPath = "Innoactive/Creator/Windows/Analytics Settings";
+        private const string menuPath = "Innoactive/Settings/Analytics Settings";
 
         private static TrackingSettingsWindow window;
 

--- a/Editor/UI/Wizard/Setup/CreatorSetupWizard.cs
+++ b/Editor/UI/Wizard/Setup/CreatorSetupWizard.cs
@@ -34,7 +34,7 @@ namespace Innoactive.CreatorEditor.UI.Wizard
             }
         }
 
-        [MenuItem("Innoactive/Creator/Create New Course...")]
+        [MenuItem("Innoactive/Create New Course...", false, 0)]
         public static void Show()
         {
             WizardWindow wizard = ScriptableObject.CreateInstance<WizardWindow>();

--- a/Editor/UI/Wizard/Setup/TrainingSceneSetupPage.cs
+++ b/Editor/UI/Wizard/Setup/TrainingSceneSetupPage.cs
@@ -53,8 +53,13 @@ namespace Innoactive.CreatorEditor.UI.Wizard
                 CanProceed = true;
             }
 
-            useCurrentScene = GUILayout.Toggle(useCurrentScene, "Take my current scene", CreatorEditorStyles.Toggle);
-            useCurrentScene = GUILayout.Toggle(!useCurrentScene, "Create a new scene", CreatorEditorStyles.Toggle) == false;
+            GUILayout.BeginHorizontal();
+                GUILayout.Space(CreatorEditorStyles.Indent);
+                GUILayout.BeginVertical();
+                useCurrentScene = GUILayout.Toggle(useCurrentScene, "Take my current scene", CreatorEditorStyles.RadioButton);
+                useCurrentScene = GUILayout.Toggle(!useCurrentScene, "Create a new scene", CreatorEditorStyles.RadioButton) == false;
+                GUILayout.EndVertical();
+            GUILayout.EndHorizontal();
 
             if (useCurrentScene == false)
             {


### PR DESCRIPTION
### Description
Introduces an "Open Course..." window which allows the user to open a training course for his/her current scene.

### Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### Aditional Notes
User can choose from courses through a dropdown
![image](https://user-images.githubusercontent.com/3699271/91960550-4c132380-ed0a-11ea-9566-f27cc741e934.png)

Notifies the user if there are no courses existent in the project
![image](https://user-images.githubusercontent.com/3699271/91960281-022a3d80-ed0a-11ea-82bb-910767c63056.png)

Notifies the user if the current scene is not setup as a training scene
![image](https://user-images.githubusercontent.com/3699271/91960418-2dad2800-ed0a-11ea-8678-2b9896bc4bfd.png)


