### PR TITLE
fix: dynamic link to community

### DIFF
--- a/Editor/UI/Wizard/Setup/AllAboutPage.cs
+++ b/Editor/UI/Wizard/Setup/AllAboutPage.cs
@@ -23,7 +23,7 @@ namespace Innoactive.CreatorEditor.UI.Wizard
                 GUILayout.Label("Need Help?", CreatorEditorStyles.Header);
 
                 CreatorGUILayout.DrawLink("In-depth webinar on how the Creator works", "https://vimeo.com/417328541/93a752e72c", CreatorEditorStyles.IndentLarge);
-                CreatorGUILayout.DrawLink("Visit our developer community", "https://spectrum.chat/innoactive-creator", CreatorEditorStyles.IndentLarge);
+                CreatorGUILayout.DrawLink("Visit our developer community", "https://innoactive.io/creator/community", CreatorEditorStyles.IndentLarge);
                 CreatorGUILayout.DrawLink("Contact Us for Support", "https://www.innoactive.io/support", CreatorEditorStyles.IndentLarge);
 
                 GUILayout.Space(CreatorEditorStyles.Indent);

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can find contacts of current maintainers in the [Maintainers](.github/CONTRI
 
 ## Community
 
-Join our [spectrum community](https://spectrum.chat/innoactive-creator?tab=posts)!
+Join our [spectrum community](https://innoactive.io/creator/community?tab=posts)!
 
 ## License
 


### PR DESCRIPTION
### Description

Prevents link to community from breaking when community's url changes or community is moved off spectrum.chat.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Ran through wizard, clicked on the Community Link, browser opened at `https://innoactive.io/creator/community` and redirected automatically to `https://spectrum.chat/innoactive-creator`

### Checklist
<!--- Make sure your PR meets the following criteria before opening it. -->

- [x] My code follows the [Coding Conventions](#coding-conventions)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules