### PR TITLE
feat(assembly-checker): added assembly checker for symbols

### DIFF
--- a/Editor/Unity/AssemblySymbolChecker.cs
+++ b/Editor/Unity/AssemblySymbolChecker.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Innoactive.CreatorEditor;
+using UnityEditor;
+
+/// <summary>
+/// Checks for assemblies specified and adds/removes the symbol according to there existence.
+/// </summary>
+[InitializeOnLoad]
+internal class AssemblySymbolChecker
+{
+    static AssemblySymbolChecker()
+    {
+        CheckForClass("Innoactive.CreatorEditor", "Innoactive.CreatorEditor.CourseValidation.ValidationHandler", "CREATOR_PRO");
+        CheckForAssembly("Innoactive.Creator.BasicInteraction", "BASIC_INTERACTION");
+    }
+
+    /// <summary>
+    /// Tries to find the given assembly name, and add/removes the symbol according to the existence of it.
+    /// </summary>
+    /// <param name="assemblyName">The assembly name looked for, just the name, no full name.</param>
+    /// <param name="symbol">The symbol added/removed.</param>
+    public static void CheckForAssembly(string assemblyName, string symbol)
+    {
+        if (EditorReflectionUtils.AssemblyExists(assemblyName))
+        {
+            AddSymbol(symbol);
+        }
+        else
+        {
+            RemoveSymbol(symbol);
+        }
+
+    }
+
+    /// <summary>
+    /// Tries to find the given assembly name, and add/removes the symbol according to the existence of it.
+    /// </summary>
+    /// <param name="assemblyName">The assembly name looked for, just the name, no full name.</param>
+    /// <param name="className">The class name looked for.</param>
+    /// <param name="symbol">The symbol added/removed.</param>
+    public static void CheckForClass(string assemblyName, string className, string symbol)
+    {
+        if (EditorReflectionUtils.ClassExists(assemblyName, className))
+        {
+            AddSymbol(symbol);
+        }
+        else
+        {
+            RemoveSymbol(symbol);
+        }
+    }
+
+    public static void AddSymbol(string symbol)
+    {
+        BuildTarget buildTarget = EditorUserBuildSettings.activeBuildTarget;
+        BuildTargetGroup buildTargetGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);
+        List<string> symbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup).Split(';').ToList();
+
+        if (symbols.Contains(symbol) == false)
+        {
+            symbols.Add(symbol);
+            PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, string.Join(";", symbols.ToArray()));
+        }
+    }
+
+    public static void RemoveSymbol(string symbol)
+    {
+        BuildTarget buildTarget = EditorUserBuildSettings.activeBuildTarget;
+        BuildTargetGroup buildTargetGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);
+        List<string> symbols = PlayerSettings.GetScriptingDefineSymbolsForGroup(buildTargetGroup).Split(';').ToList();
+
+        if (symbols.Contains(symbol))
+        {
+            symbols.Remove(symbol);
+            PlayerSettings.SetScriptingDefineSymbolsForGroup(buildTargetGroup, string.Join(";", symbols.ToArray()));
+        }
+    }
+}

--- a/Editor/Unity/AssemblySymbolChecker.cs
+++ b/Editor/Unity/AssemblySymbolChecker.cs
@@ -30,7 +30,6 @@ internal class AssemblySymbolChecker
         {
             RemoveSymbol(symbol);
         }
-
     }
 
     /// <summary>
@@ -51,7 +50,7 @@ internal class AssemblySymbolChecker
         }
     }
 
-    public static void AddSymbol(string symbol)
+    private static void AddSymbol(string symbol)
     {
         BuildTarget buildTarget = EditorUserBuildSettings.activeBuildTarget;
         BuildTargetGroup buildTargetGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);
@@ -64,7 +63,7 @@ internal class AssemblySymbolChecker
         }
     }
 
-    public static void RemoveSymbol(string symbol)
+    private static void RemoveSymbol(string symbol)
     {
         BuildTarget buildTarget = EditorUserBuildSettings.activeBuildTarget;
         BuildTargetGroup buildTargetGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);

--- a/Editor/Unity/AssemblySymbolChecker.cs.meta
+++ b/Editor/Unity/AssemblySymbolChecker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e56919c4984d4c4690dcb1397bb21fc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Description
The added script checks for specific assemblies exist and adds/removes a symbol accordingly.

**Fixes**: 
- Problems with integrating pro stuff for specific components.

### Type of change
- [x] Internal

### How Has This Been Tested?
BASIC_INTERACTION symbol is only existent when the assemblie for it is loaded.