### PR TITLE
ci: replace tracking id when releasing

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -5,6 +5,11 @@ resources:
     endpoint: Innoactive
     name: Innoactive/Empty-Unity-Project-2019
     ref: develop
+  - repository: Templates
+    type: github
+    endpoint: Innoactive
+    name: Innoactive/Creator-Azure-Templates
+    ref: master
 
 trigger:
     - master
@@ -96,6 +101,13 @@ stages:
           workingDirectory: "Creator/"
         env:
           GH_TOKEN: "$(GITHUB_TOKEN)"
+  
+      - template: replace-string.yml@Templates
+        parameters:
+          FilePathInCreator: 'Core/Editor/Analytics/GoogleTracker.cs'
+          OldString: '$(DEV_TRACKING_ID)'
+          NewString: '$(LIVE_TRACKING_ID)'
+          Condition: eq(variables['Build.SourceBranchName'], 'master')
 
       - task: PowerShell@2
         displayName: Fetch version from git


### PR DESCRIPTION
# Description
The development tracking ID for Google Analytics gets replaced when building a release.


### Type of change
<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)