### PR TITLE
fix: fixed a missing entity ex for missing scene objects on unlock tab

### DIFF
--- a/Runtime/LockableObjectsCollection.cs
+++ b/Runtime/LockableObjectsCollection.cs
@@ -29,6 +29,8 @@ namespace Innoactive.Creator.Core
 
         private void CreateSceneObjects()
         {
+            CleanProperties();
+
             foreach (LockablePropertyReference propertyReference in data.ToUnlock)
             {
                 AddSceneObject(propertyReference.Target.Value);
@@ -109,6 +111,11 @@ namespace Innoactive.Creator.Core
         public void Add(LockableProperty property)
         {
             data.ToUnlock = data.ToUnlock.Union(new [] {new LockablePropertyReference(property), }).ToList();
+        }
+
+        private void CleanProperties()
+        {
+            data.ToUnlock = data.ToUnlock.Where(reference => reference.Target.IsEmpty() == false).ToList();
         }
     }
 }


### PR DESCRIPTION
### Description
opening a step made a lot of missing entity exception pop up, when there was a object added to the "ToUnlock" field of a step which is not in the scene. Fixed this by cleaning up the to unlock list before using it.