### PR TITLE
feat: displayed course changes to match scene selected TRNG-1302

### DIFF
--- a/Editor/DefaultEditingStrategy.cs
+++ b/Editor/DefaultEditingStrategy.cs
@@ -1,10 +1,8 @@
-using Innoactive.Creator.Core;
-using Innoactive.Creator.Core.Configuration;
-using Innoactive.CreatorEditor.Configuration;
-using Innoactive.CreatorEditor.CourseValidation;
-using Innoactive.CreatorEditor.UI.Windows;
 using UnityEditor;
 using UnityEngine;
+using Innoactive.Creator.Core;
+using Innoactive.CreatorEditor.UI.Windows;
+using Innoactive.CreatorEditor.Configuration;
 
 namespace Innoactive.CreatorEditor
 {

--- a/Editor/GlobalEditorHandler.cs
+++ b/Editor/GlobalEditorHandler.cs
@@ -1,7 +1,10 @@
-using Innoactive.Creator.Core;
-using Innoactive.CreatorEditor.UI.Windows;
 using UnityEditor;
 using UnityEngine;
+using UnityEditor.SceneManagement;
+using UnityEngine.SceneManagement;
+using Innoactive.Creator.Core;
+using Innoactive.CreatorEditor.UI.Windows;
+using Innoactive.Creator.Core.Configuration;
 
 namespace Innoactive.CreatorEditor
 {
@@ -21,6 +24,8 @@ namespace Innoactive.CreatorEditor
 
             string lastEditedCourseName = EditorPrefs.GetString(LastEditedCourseNameKey);
             SetCurrentCourse(lastEditedCourseName);
+
+            EditorSceneManager.sceneOpened += OnSceneOpened;
         }
 
         /// <summary>
@@ -157,6 +162,26 @@ namespace Innoactive.CreatorEditor
         internal static void ExitPlayMode()
         {
             strategy.HandleExitingPlayMode();
+        }
+
+        private static void OnSceneOpened(Scene scene, OpenSceneMode mode)
+        {
+            if (RuntimeConfigurator.Exists == false)
+            {
+                SetCurrentCourse(string.Empty);
+                return;
+            }
+
+            string coursePath = RuntimeConfigurator.Instance.GetSelectedCourse();
+
+            if (string.IsNullOrEmpty(coursePath))
+            {
+                SetCurrentCourse(string.Empty);
+                return;
+            }
+
+            string courseName = System.IO.Path.GetFileNameWithoutExtension(coursePath);
+            SetCurrentCourse(courseName);
         }
     }
 }

--- a/Editor/UI/Drawers/UniqueNameReferenceDrawer.cs
+++ b/Editor/UI/Drawers/UniqueNameReferenceDrawer.cs
@@ -42,8 +42,9 @@ namespace Innoactive.CreatorEditor.UI.Drawers
 
             string newUniqueName = GetIDFromSelectedObject(selectedSceneObject, valueType, oldUniqueName);
 
-            if (oldUniqueName != newUniqueName)
+            if (oldUniqueName != newUniqueName && string.IsNullOrEmpty(newUniqueName) == false)
             {
+                Debug.LogWarning($"Changing\nOld:[´{oldUniqueName}, New: {newUniqueName}");
                 RevertableChangesHandler.Do(
                     new CourseCommand(
                         () =>
@@ -81,7 +82,7 @@ namespace Innoactive.CreatorEditor.UI.Drawers
 
                 if (gameObject == null)
                 {
-                    Debug.LogWarningFormat("{0} with Unique Name \"{1}\" could not be found.", valueType.Name, objectUniqueName);
+                    Debug.LogError($"{valueType.Name} with Unique Name \"{objectUniqueName}\" could not be found.");
                 }
 
                 return gameObject;
@@ -119,10 +120,9 @@ namespace Innoactive.CreatorEditor.UI.Drawers
 
         private GameObject GetGameObjectFromInstanceID(string objectUniqueName)
         {
-            int instanceId;
             GameObject gameObject = null;
 
-            if (int.TryParse(objectUniqueName, out instanceId))
+            if (int.TryParse(objectUniqueName, out int instanceId))
             {
                 gameObject = EditorUtility.InstanceIDToObject(instanceId) as GameObject;
             }
@@ -139,20 +139,18 @@ namespace Innoactive.CreatorEditor.UI.Drawers
                 return sceneObject.UniqueName;
             }
 
-            Debug.LogWarningFormat("Game Object \"{0}\" does not have a Training Scene Object component.", selectedSceneObject.name);
+            Debug.LogWarning($"Game Object \"{selectedSceneObject.name}\" does not have a Training Scene Object component.");
             return string.Empty;
         }
 
         private string GetUniqueNameFromTrainingProperty(GameObject selectedTrainingPropertyObject, Type valueType, string oldUniqueName)
         {
-            ISceneObjectProperty trainingProperty = selectedTrainingPropertyObject.GetComponent(valueType) as ISceneObjectProperty;
-
-            if (trainingProperty != null)
+            if (selectedTrainingPropertyObject.GetComponent(valueType) is ISceneObjectProperty trainingProperty)
             {
                 return trainingProperty.SceneObject.UniqueName;
             }
 
-            Debug.LogWarningFormat("Scene Object \"{0}\" with Unique Name \"{1}\" does not have a {2} component.", selectedTrainingPropertyObject.name, oldUniqueName, valueType.Name);
+            Debug.LogWarning($"Scene Object \"{selectedTrainingPropertyObject.name}\" with Unique Name \"{oldUniqueName}\" does not have a {valueType.Name} component.");
             return string.Empty;
         }
 
@@ -160,7 +158,7 @@ namespace Innoactive.CreatorEditor.UI.Drawers
         {
             if (selectedSceneObject != null && selectedSceneObject.GetComponent(valueType) == null)
             {
-                string warning = string.Format("{0} is not configured as {1}", selectedSceneObject.name, valueType.Name);
+                string warning = $"{selectedSceneObject.name} is not configured as {valueType.Name}";
                 const string button = "Fix it";
 
                 EditorGUI.HelpBox(guiLineRect, warning, MessageType.Error);

--- a/Editor/UI/Drawers/UniqueNameReferenceDrawer.cs
+++ b/Editor/UI/Drawers/UniqueNameReferenceDrawer.cs
@@ -44,7 +44,6 @@ namespace Innoactive.CreatorEditor.UI.Drawers
 
             if (oldUniqueName != newUniqueName && string.IsNullOrEmpty(newUniqueName) == false)
             {
-                Debug.LogWarning($"Changing\nOld:[´{oldUniqueName}, New: {newUniqueName}");
                 RevertableChangesHandler.Do(
                     new CourseCommand(
                         () =>

--- a/Editor/UI/Windows/CourseWindow.cs
+++ b/Editor/UI/Windows/CourseWindow.cs
@@ -108,16 +108,16 @@ namespace Innoactive.CreatorEditor.UI.Windows
             }
 
             EditorSceneManager.newSceneCreated += OnNewScene;
-            EditorSceneManager.sceneOpened += OnSceneOpened;
             EditorSceneManager.sceneClosing += OnSceneClosed;
+            EditorSceneManager.sceneOpened += OnSceneOpened;
             GlobalEditorHandler.CourseWindowOpened(this);
         }
 
         private void OnDestroy()
         {
             EditorSceneManager.newSceneCreated -= OnNewScene;
-            EditorSceneManager.sceneOpened -= OnSceneOpened;
             EditorSceneManager.sceneClosing -= OnSceneClosed;
+            EditorSceneManager.sceneOpened -= OnSceneOpened;
             GlobalEditorHandler.CourseWindowClosed(this);
         }
 
@@ -228,19 +228,7 @@ namespace Innoactive.CreatorEditor.UI.Windows
             if (RuntimeConfigurator.Exists == false)
             {
                 Close();
-                return;
             }
-
-            string coursePath = RuntimeConfigurator.Instance.GetSelectedCourse();
-
-            if (string.IsNullOrEmpty(coursePath))
-            {
-                Close();
-                return;
-            }
-
-            string courseName = Path.GetFileNameWithoutExtension(coursePath);
-            GlobalEditorHandler.SetCurrentCourse(courseName);
         }
 
         private void OnSceneClosed(Scene scene, bool removingscene)

--- a/Editor/UI/Windows/CourseWindow.cs
+++ b/Editor/UI/Windows/CourseWindow.cs
@@ -1,5 +1,3 @@
-using System;
-using System.IO;
 using UnityEditor;
 using UnityEngine;
 using UnityEditor.SceneManagement;
@@ -7,6 +5,7 @@ using UnityEngine.SceneManagement;
 using Innoactive.Creator.Core;
 using Innoactive.CreatorEditor.UndoRedo;
 using Innoactive.Creator.Core.Configuration;
+using Innoactive.CreatorEditor.Configuration;
 
 namespace Innoactive.CreatorEditor.UI.Windows
 {
@@ -152,11 +151,6 @@ namespace Innoactive.CreatorEditor.UI.Windows
             {
                 EditorConfigurator.Instance.Validation.Validate(activeCourse.Data, GlobalEditorHandler.GetCurrentCourse());
             }
-        }
-
-        private void OnDestroy()
-        {
-            GlobalEditorHandler.CourseWindowClosed(this);
         }
 
         private void HandleEditorCommands(Vector2 centerViewpointOnCanvas)

--- a/Editor/UI/Windows/StepWindow.cs
+++ b/Editor/UI/Windows/StepWindow.cs
@@ -1,16 +1,15 @@
+using UnityEditor;
+using UnityEngine;
+using UnityEditor.SceneManagement;
+using UnityEngine.SceneManagement;
 using System.Collections.Generic;
 using Innoactive.Creator.Core;
 using Innoactive.CreatorEditor.Tabs;
-using Innoactive.Creator.Core.Configuration;
-using Innoactive.CreatorEditor.Configuration;
-using Innoactive.CreatorEditor.CourseValidation;
 using Innoactive.CreatorEditor.UI.Drawers;
-using UnityEditor;
-using UnityEngine;
+using Innoactive.CreatorEditor.Configuration;
 
 namespace Innoactive.CreatorEditor.UI.Windows
 {
-    /// <inheritdoc />
     /// <summary>
     /// This class draws the Step Inspector.
     /// </summary>
@@ -43,11 +42,13 @@ namespace Innoactive.CreatorEditor.UI.Windows
 
         private void OnEnable()
         {
+            EditorSceneManager.sceneClosing += OnSceneClosed;
             GlobalEditorHandler.StepWindowOpened(this);
         }
 
         private void OnDestroy()
         {
+            EditorSceneManager.sceneClosing -= OnSceneClosed;
             GlobalEditorHandler.StepWindowClosed(this);
         }
 
@@ -56,7 +57,7 @@ namespace Innoactive.CreatorEditor.UI.Windows
             Repaint();
         }
 
-        void OnFocus()
+        private void OnFocus()
         {
             if (step?.Data == null)
             {
@@ -94,6 +95,11 @@ namespace Innoactive.CreatorEditor.UI.Windows
                 stepRect = new Rect(stepDrawingRect.position - new Vector2(border,border), stepDrawingRect.size + new Vector2(border * 2f, border * 2f));
             }
             GUI.EndScrollView();
+        }
+
+        private void OnSceneClosed(Scene scene, bool removingscene)
+        {
+            SetStep(null);
         }
 
         private void ModifyStep(object newStep)


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

The workflow editor and the step inspector flush their content when changing scenes, additionally, if the new scene is a valid training scene with a new course, that course is loaded automatically.

### Type of change
<!--- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Open a scene with a training course, then open a course in the workflow editor, then change the scene to:

a) a new (empty) scene.
b) another scene with a `[TRAINING_CONFIGURATION]`.
c) another scene without a `[TRAINING_CONFIGURATION]` 