### PR TITLE
fix: existing training wont stop you from starting the step guide

### DIFF
--- a/Editor/UI/Wizard/Setup/TrainingSceneSetupPage.cs
+++ b/Editor/UI/Wizard/Setup/TrainingSceneSetupPage.cs
@@ -87,6 +87,7 @@ namespace Innoactive.CreatorEditor.UI.Wizard
                 {
                     createNewScene = false;
                     useCurrentScene = false;
+                    CanProceed = true;
 
                     GUILayout.BeginHorizontal();
                     {


### PR DESCRIPTION
### Description
wizard did not allow to continue when you wanted to create a new step by step guide while the course name was already existing.
