### PR TITLE
ci: exporter fails the batch command when export fails

### DIFF
--- a/Editor/PackageExporter.cs
+++ b/Editor/PackageExporter.cs
@@ -38,6 +38,10 @@ namespace Innoactive.CreatorEditor
             catch (Exception ex)
             {
                 Debug.LogError(ex);
+                if (Application.isBatchMode)
+                {
+                    EditorApplication.Exit(1);
+                }
             }
         }
 


### PR DESCRIPTION
### Description
Pipeline is green while there was an error in exporting the unitypackage. This should fix it.