### PR TITLE
fix: fixed the return value of newly created project settings

### DIFF
--- a/Editor/Analytics/VersionCheckerEvent.cs
+++ b/Editor/Analytics/VersionCheckerEvent.cs
@@ -1,6 +1,7 @@
 ﻿using Innoactive.CreatorEditor;
 using Innoactive.CreatorEditor.Analytics;
 using UnityEditor;
+using UnityEngine;
 
 namespace Innoactive.Creator.Core.Editor
 {
@@ -14,9 +15,13 @@ namespace Innoactive.Creator.Core.Editor
 
         static VersionCheckerEvent()
         {
-            CreatorProjectSettings settings = CreatorProjectSettings.Load();
+            if (Application.isBatchMode)
+            {
+                return;
+            }
 
-            if (string.IsNullOrEmpty(settings.ProjectCreatorVersion))
+            CreatorProjectSettings settings = CreatorProjectSettings.Load();
+            if (settings == null || string.IsNullOrEmpty(settings.ProjectCreatorVersion))
             {
                 return;
             }

--- a/Editor/CreatorProjectSettings.cs
+++ b/Editor/CreatorProjectSettings.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using Innoactive.CreatorEditor;
 using UnityEditor;
 using UnityEngine;
@@ -40,7 +39,7 @@ public partial class CreatorProjectSettings : ScriptableObject
             AssetDatabase.SaveAssets();
             AssetDatabase.Refresh();
 
-            return Resources.Load<CreatorProjectSettings>("CreatorProjectSettings");
+            return settings;
         }
         return settings;
     }


### PR DESCRIPTION
### Description
CreatorProjectSettings loader sometimes returns null. Should be fixed, also only running the version checker when it's not int batch mode.