### PR TITLE
Bugfix/too long courses crash TRNG-1316

### DIFF
--- a/Editor/Configuration/DefaultEditorConfiguration.cs
+++ b/Editor/Configuration/DefaultEditorConfiguration.cs
@@ -31,7 +31,7 @@ namespace Innoactive.CreatorEditor.Configuration
         /// <inheritdoc />
         public virtual ICourseSerializer Serializer
         {
-            get { return new NewtonsoftJsonCourseSerializer(); }
+            get { return new ImprovedNewtonsoftJsonCourseSerializer(); }
         }
 
         /// <inheritdoc />

--- a/Runtime/Configuration/BaseRuntimeConfiguration.cs
+++ b/Runtime/Configuration/BaseRuntimeConfiguration.cs
@@ -33,7 +33,7 @@ namespace Innoactive.Creator.Core.Configuration
         }
 
         /// <inheritdoc />
-        public ICourseSerializer Serializer { get; set; } = new NewtonsoftJsonCourseSerializer();
+        public ICourseSerializer Serializer { get; set; } = new ImprovedNewtonsoftJsonCourseSerializer();
 
         /// <inheritdoc />
         public IModeHandler Modes { get; protected set; }

--- a/Runtime/Serialization/NewtonsoftJsonSerializer/ImprovedNewtonSoftJsonCourseSerializer.cs.meta
+++ b/Runtime/Serialization/NewtonsoftJsonSerializer/ImprovedNewtonSoftJsonCourseSerializer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1a3877cbf4d84c49bc7a204bb5d43464
+timeCreated: 1605778759

--- a/Runtime/Serialization/NewtonsoftJsonSerializer/ImprovedNewtonsoftJsonCourseSerializer.cs
+++ b/Runtime/Serialization/NewtonsoftJsonSerializer/ImprovedNewtonsoftJsonCourseSerializer.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+using Innoactive.Creator.Core.Configuration.Modes;
+using Innoactive.Creator.Core.Serialization.NewtonsoftJson;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Innoactive.Creator.Core.Serialization
+{
+    public class ImprovedNewtonsoftJsonCourseSerializer : NewtonsoftJsonCourseSerializer
+    {
+        /// <inheritdoc/>
+        public override string Name { get; } = "Improved Newtonsoft Json Importer";
+
+        protected override int Version { get; } = 2;
+
+        public override ICourse CourseFromByteArray(byte[] data)
+        {
+            string stringData = new UTF8Encoding().GetString(data);
+            JObject dataObject = JsonConvert.DeserializeObject<JObject>(stringData, CourseSerializerSettings);
+
+            // Check if course was serialized with version 1
+            int version = dataObject.GetValue("$serializerVersion").ToObject<int>();
+            if (version == 1)
+            {
+                return base.CourseFromByteArray(data);
+            }
+
+            CourseWrapper wrapper = Deserialize<CourseWrapper>(data, CourseSerializerSettings);
+            return wrapper.GetCourse();
+        }
+
+        public override byte[] CourseToByteArray(ICourse course)
+        {
+            CourseWrapper wrapper = new CourseWrapper(course);
+            JObject jObject = JObject.FromObject(wrapper, JsonSerializer.Create(CourseSerializerSettings));
+            jObject.Add("$serializerVersion", Version);
+            // This line is required to undo the changes applied to the course.
+            wrapper.GetCourse();
+
+            return new UTF8Encoding().GetBytes(jObject.ToString());
+        }
+
+        [Serializable]
+        private class CourseWrapper
+        {
+            [DataMember]
+            public List<IStep> Steps = new List<IStep>();
+
+            [DataMember]
+            public ICourse Course;
+
+            public CourseWrapper()
+            {
+
+            }
+
+            public CourseWrapper(ICourse course)
+            {
+                foreach (IChapter chapter in course.Data.Chapters)
+                {
+                    Steps.AddRange(chapter.Data.Steps);
+                }
+
+                foreach (IStep step in Steps)
+                {
+                    foreach (ITransition transition in step.Data.Transitions.Data.Transitions)
+                    {
+                        if (transition.Data.TargetStep != null)
+                        {
+                            transition.Data.TargetStep = new StepRef() { PositionIndex = Steps.IndexOf(transition.Data.TargetStep) };
+                        }
+                    }
+                }
+                Course = course;
+            }
+
+            public ICourse GetCourse()
+            {
+                foreach (IStep step in Steps)
+                {
+                    foreach (ITransition transition in step.Data.Transitions.Data.Transitions)
+                    {
+                        if (transition.Data.TargetStep == null)
+                        {
+                            continue;
+                        }
+
+                        StepRef stepRef = (StepRef) transition.Data.TargetStep;
+                        transition.Data.TargetStep = stepRef.PositionIndex >= 0 ? Steps[stepRef.PositionIndex] : null;
+                    }
+                }
+
+                return Course;
+            }
+
+            [Serializable]
+            public class StepRef : IStep
+            {
+                [DataMember]
+                public int PositionIndex = -1;
+
+                private IData data;
+                private IStepData data1;
+
+                IData IDataOwner.Data => data;
+
+                IStepData IDataOwner<IStepData>.Data => data1;
+
+                public ILifeCycle LifeCycle { get; }
+
+                public IProcess GetActivatingProcess()
+                {
+                    throw new NotImplementedException();
+                }
+
+                public IProcess GetActiveProcess()
+                {
+                    throw new NotImplementedException();
+                }
+
+                public IProcess GetDeactivatingProcess()
+                {
+                    throw new NotImplementedException();
+                }
+
+                public void Configure(IMode mode)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public void Update()
+                {
+                    throw new NotImplementedException();
+                }
+
+                public StepMetadata StepMetadata { get; set; }
+            }
+        }
+    }
+}

--- a/Runtime/Serialization/NewtonsoftJsonSerializer/ImprovedNewtonsoftJsonCourseSerializer.cs
+++ b/Runtime/Serialization/NewtonsoftJsonSerializer/ImprovedNewtonsoftJsonCourseSerializer.cs
@@ -102,14 +102,11 @@ namespace Innoactive.Creator.Core.Serialization
                 [DataMember]
                 public int PositionIndex = -1;
 
-                private IData data;
-                private IStepData data1;
+                IData IDataOwner.Data { get; } = null;
 
-                IData IDataOwner.Data => data;
+                IStepData IDataOwner<IStepData>.Data { get; } = null;
 
-                IStepData IDataOwner<IStepData>.Data => data1;
-
-                public ILifeCycle LifeCycle { get; }
+                public ILifeCycle LifeCycle { get; } = null;
 
                 public IProcess GetActivatingProcess()
                 {

--- a/Runtime/Serialization/NewtonsoftJsonSerializer/ImprovedNewtonsoftJsonCourseSerializer.cs
+++ b/Runtime/Serialization/NewtonsoftJsonSerializer/ImprovedNewtonsoftJsonCourseSerializer.cs
@@ -9,6 +9,9 @@ using Newtonsoft.Json.Linq;
 
 namespace Innoactive.Creator.Core.Serialization
 {
+    /// <summary>
+    /// Improved version of the NewtonsoftJsonCourseSerializer, which now allows to serialize very long chapters.
+    /// </summary>
     public class ImprovedNewtonsoftJsonCourseSerializer : NewtonsoftJsonCourseSerializer
     {
         /// <inheritdoc/>
@@ -16,6 +19,7 @@ namespace Innoactive.Creator.Core.Serialization
 
         protected override int Version { get; } = 2;
 
+        /// <inheritdoc/>
         public override ICourse CourseFromByteArray(byte[] data)
         {
             string stringData = new UTF8Encoding().GetString(data);
@@ -32,6 +36,7 @@ namespace Innoactive.Creator.Core.Serialization
             return wrapper.GetCourse();
         }
 
+        /// <inheritdoc/>
         public override byte[] CourseToByteArray(ICourse course)
         {
             CourseWrapper wrapper = new CourseWrapper(course);

--- a/Runtime/Serialization/NewtonsoftJsonSerializer/NewtonsoftJsonCourseSerializer.cs
+++ b/Runtime/Serialization/NewtonsoftJsonSerializer/NewtonsoftJsonCourseSerializer.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Boo.Lang.Runtime;
 using Innoactive.Creator.Core.UI.Drawers.Metadata;
 using Innoactive.Creator.Core.Utils;
 using Newtonsoft.Json;
@@ -99,7 +98,7 @@ namespace Innoactive.Creator.Core.Serialization.NewtonsoftJson
             int version = dataObject.GetValue("$serializerVersion").ToObject<int>();
             if (version != 1)
             {
-                throw new RuntimeException($"The loaded course is serialized with a serializer version {version}, which in compatible with this serializer.");
+                throw new Exception($"The loaded course is serialized with a serializer version {version}, which in compatible with this serializer.");
             }
 
             return Deserialize<ICourse>(data, CourseSerializerSettings);

--- a/Runtime/Serialization/NewtonsoftJsonSerializer/NewtonsoftJsonCourseSerializer.cs
+++ b/Runtime/Serialization/NewtonsoftJsonSerializer/NewtonsoftJsonCourseSerializer.cs
@@ -15,7 +15,7 @@ namespace Innoactive.Creator.Core.Serialization.NewtonsoftJson
     /// </summary>
     public class NewtonsoftJsonCourseSerializer : ICourseSerializer
     {
-        private static int Version { get; } = 1;
+        protected virtual int Version { get; } = 1;
 
         private static JsonSerializerSettings CreateSettings(IList<JsonConverter> converters)
         {
@@ -65,19 +65,19 @@ namespace Innoactive.Creator.Core.Serialization.NewtonsoftJson
         }
 
         /// <inheritdoc/>
-        public string Name { get; } = "Newtonsoft Json Importer";
+        public virtual string Name { get; } = "Newtonsoft Json Importer";
 
         /// <inheritdoc/>
-        public string FileFormat { get; } = "json";
+        public virtual string FileFormat { get; } = "json";
 
-        private static byte[] Serialize(IEntity entity, JsonSerializerSettings settings)
+        protected  byte[] Serialize(IEntity entity, JsonSerializerSettings settings)
         {
             JObject jObject = JObject.FromObject(entity, JsonSerializer.Create(settings));
             jObject.Add("$serializerVersion", Version);
             return new UTF8Encoding().GetBytes(jObject.ToString());
         }
 
-        private static T Deserialize<T>(byte[] data, JsonSerializerSettings settings)
+        protected T Deserialize<T>(byte[] data, JsonSerializerSettings settings)
         {
             string stringData = new UTF8Encoding().GetString(data);
             return (T)JsonConvert.DeserializeObject(stringData, settings);

--- a/Runtime/Serialization/NewtonsoftJsonSerializer/NewtonsoftJsonCourseSerializer.cs
+++ b/Runtime/Serialization/NewtonsoftJsonSerializer/NewtonsoftJsonCourseSerializer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Boo.Lang.Runtime;
 using Innoactive.Creator.Core.UI.Drawers.Metadata;
 using Innoactive.Creator.Core.Utils;
 using Newtonsoft.Json;
@@ -92,6 +93,15 @@ namespace Innoactive.Creator.Core.Serialization.NewtonsoftJson
         /// <inheritdoc/>
         public virtual ICourse CourseFromByteArray(byte[] data)
         {
+            JObject dataObject = JsonConvert.DeserializeObject<JObject>(new UTF8Encoding().GetString(data), CourseSerializerSettings);
+
+            // Check if course was serialized with version 1
+            int version = dataObject.GetValue("$serializerVersion").ToObject<int>();
+            if (version != 1)
+            {
+                throw new RuntimeException($"The loaded course is serialized with a serializer version {version}, which in compatible with this serializer.");
+            }
+
             return Deserialize<ICourse>(data, CourseSerializerSettings);
         }
 

--- a/Tests/Serialization/SerializationLengthTests.cs
+++ b/Tests/Serialization/SerializationLengthTests.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Linq;
+using Innoactive.Creator.Core;
+using Innoactive.Creator.Core.Serialization;
+using Innoactive.Creator.Tests.Builder;
+using NUnit.Framework;
+
+namespace Innoactive.CreatorEditor.Tests
+{
+    public class SerializationLengthTests
+    {
+
+        [Test]
+        public void RunSerializerWithLinear()
+        {
+            int length = 100;
+            ICourse course = CreateTrainingCourse(length);
+
+            ImprovedNewtonsoftJsonCourseSerializer serializer = new ImprovedNewtonsoftJsonCourseSerializer();
+            try
+            {
+                byte[] data = serializer.CourseToByteArray(course);
+                serializer.CourseFromByteArray(data);
+            }
+            catch (Exception)
+            {
+                Assert.Fail("failed with a length of: " + length);
+            }
+        }
+
+        [Test]
+        public void RunSerializerWithSplit()
+        {
+            int length = 200;
+            ICourse course = CreateSplitTrainingCourse(length);
+
+            ImprovedNewtonsoftJsonCourseSerializer serializer = new ImprovedNewtonsoftJsonCourseSerializer();
+            try
+            {
+                byte[] data = serializer.CourseToByteArray(course);
+                serializer.CourseFromByteArray(data);
+            }
+            catch (Exception)
+            {
+                Assert.Fail("failed with a length of: " + length);
+            }
+        }
+
+        [Test]
+        public void RunSerializerWithEarlyFinish()
+        {
+            int length = 500;
+            ICourse course = CreateTrainingCourse(length);
+
+            ImprovedNewtonsoftJsonCourseSerializer serializer = new ImprovedNewtonsoftJsonCourseSerializer();
+            try
+            {
+                Transition t1 = new Transition();
+                t1.Data.TargetStep = null;
+                course.Data.Chapters[0].Data.Steps.First().Data.Transitions.Data.Transitions.Insert(0, t1);
+
+                byte[] data = serializer.CourseToByteArray(course);
+                serializer.CourseFromByteArray(data);
+            }
+            catch (Exception)
+            {
+                Assert.Fail("failed with a length of: " + length);
+            }
+        }
+
+        private ICourse CreateTrainingCourse(int length)
+        {
+
+            LinearChapterBuilder chapterBuilder = new LinearChapterBuilder("chapter");
+            for (int i = 0; i < length; i++)
+            {
+                chapterBuilder.AddStep(new BasicStepBuilder("Step#" + i));
+            }
+
+            return new LinearTrainingBuilder("Training")
+                .AddChapter(chapterBuilder)
+                .Build();
+        }
+
+        private ICourse CreateSplitTrainingCourse(int length)
+        {
+
+            LinearChapterBuilder[] chapterBuilder = new[] {new LinearChapterBuilder("chapter"), new LinearChapterBuilder("chapter"), new LinearChapterBuilder("chapter")};
+
+            for (int c = 0; c < 3; c++)
+            {
+                for (int i = 0; i < length; i++)
+                {
+                    chapterBuilder[c].AddStep(new BasicStepBuilder("Step#" + i));
+                }
+            }
+
+            Chapter chapter = chapterBuilder[0].Build();
+
+
+            Chapter c1 = chapterBuilder[1].Build();
+            Transition t1 = new Transition();
+            t1.Data.TargetStep = c1.Data.FirstStep;
+
+
+            Chapter c2 = chapterBuilder[1].Build();
+            Transition t2 = new Transition();
+            t2.Data.TargetStep = c2.Data.FirstStep;
+
+
+            chapter.Data.FirstStep.Data.Transitions.Data.Transitions.Add(t1);
+            chapter.Data.FirstStep.Data.Transitions.Data.Transitions.Add(t2);
+
+
+            Transition t1end = new Transition();
+            t1end.Data.TargetStep = chapter.Data.Steps.Last();
+            c1.Data.Steps.Last().Data.Transitions.Data.Transitions.Add(t1end);
+
+
+            Transition t2end = new Transition();
+            t2end.Data.TargetStep = chapter.Data.Steps.Last();
+            c2.Data.Steps.Last().Data.Transitions.Data.Transitions.Add(t2end);
+
+            c1.Data.Steps.ToList().ForEach(chapter.Data.Steps.Add);
+            c2.Data.Steps.ToList().ForEach(chapter.Data.Steps.Add);
+
+            return new Course("name", chapter);
+        }
+    }
+}

--- a/Tests/Serialization/SerializationLengthTests.cs.meta
+++ b/Tests/Serialization/SerializationLengthTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: bebdb2b0864048b5a6b8a6f5d5247e38
+timeCreated: 1605781103


### PR DESCRIPTION
### Description
Our JSON course structure is too deep which leads to serialization errors. Easiest fix is listing the all steps in a big list at the beginning of the training JSON which removes depths. To make it backwards compatible I wrote a new serializer which is based on the old one.


**Fixes**: # (issue)
Our JSON course structure is too deep which leads to serialization errors.
