### PR TITLE
fix: transition joint hover color spilled over

### DIFF
--- a/Editor/UI/EditorDrawingHelper.cs
+++ b/Editor/UI/EditorDrawingHelper.cs
@@ -125,11 +125,11 @@ namespace Innoactive.CreatorEditor.UI
 
                 if (points.Count == 2)
                 {//straight line
-                    Vector3 trianglePoint = new Vector3(points[0].x + (points[1].x - points[0].x) / 5, points[0].y); 
+                    Vector3 trianglePoint = new Vector3(points[0].x + (points[1].x - points[0].x) / 5, points[0].y);
                     p1 = new Vector3(trianglePoint.x, trianglePoint.y - arrowHeadWidth / 2, 1f);
                     p2 = new Vector3(trianglePoint.x, trianglePoint.y + arrowHeadWidth / 2, 1f);
                     p3 = new Vector3(trianglePoint.x + arrowHeadHeight, trianglePoint.y, 1f);
-                } 
+                }
                 else if (points.Count > 4)
                 {
                     Vector3 from = points[2];
@@ -142,7 +142,6 @@ namespace Innoactive.CreatorEditor.UI
                     p1 = new Vector3(to.x - (arrowHeadHeight * directionalAxis.x) + (arrowHeadWidth * orthoDirectionalAxis.x / 2f), to.y - (arrowHeadHeight * directionalAxis.y) + (arrowHeadWidth * orthoDirectionalAxis.y / 2f), 1f);
                     p2 = new Vector3(to.x - (arrowHeadHeight * directionalAxis.x) - (arrowHeadWidth * orthoDirectionalAxis.x / 2f), to.y - (arrowHeadHeight * directionalAxis.y) - (arrowHeadWidth * orthoDirectionalAxis.y / 2f), 1f);
                     p3 = new Vector3(to.x, to.y, 1f);
-
                 }
                 else
                 {
@@ -299,15 +298,13 @@ namespace Innoactive.CreatorEditor.UI
         public static void DrawPolyline(IList<Vector2> points, Color color)
         {
             Vector2 lastPosition = points[0];
-
-            color = GUI.color * color;
             Color handlesColor = Handles.color;
 
             for (int i = 1; i < points.Count; i++)
             {
                 Handles.BeginGUI();
                 {
-                    Handles.color = color;
+                    Handles.color = GUI.color * color;
                     Handles.DrawBezier(lastPosition, points[i], lastPosition, points[i], color, null, StepTransitionStrokeSize);
                     Handles.color = handlesColor;
                 }
@@ -325,7 +322,6 @@ namespace Innoactive.CreatorEditor.UI
         /// <param name="color">Color or line.</param>
         public static void DrawHorizontalLine(Vector2 startPoint, float length, Color color)
         {
-            color = GUI.color * color;
             EditorGUI.DrawRect(new Rect(startPoint.x, startPoint.y, length, 1), color);
         }
 
@@ -337,8 +333,21 @@ namespace Innoactive.CreatorEditor.UI
         /// <param name="color">Color or line.</param>
         public static void DrawVerticalLine(Vector2 startPoint, float length, Color color)
         {
-            color = GUI.color * color;
             EditorGUI.DrawRect(new Rect(startPoint.x, startPoint.y, 1, length), color);
+        }
+
+        /// <summary>
+        /// Draws a texture in a specific color
+        /// </summary>
+        /// <param name="iconRect">Position and size of the texture.</param>
+        /// <param name="texture">The texture to paint.</param>
+        /// <param name="color">The color it should be painted in.</param>
+        public static void DrawTexture(Rect iconRect, Texture texture, Color color)
+        {
+            Color defaultColor = GUI.color;
+            GUI.color = color;
+            GUI.DrawTexture(iconRect, texture);
+            GUI.color = defaultColor;
         }
     }
 }

--- a/Editor/UI/Graphics/Renderers/CreateTransitionButtonRenderer.cs
+++ b/Editor/UI/Graphics/Renderers/CreateTransitionButtonRenderer.cs
@@ -1,6 +1,5 @@
 using Innoactive.CreatorEditor.UI.Graphics.Renderers;
 using UnityEngine;
-using UnityEditor;
 
 namespace Innoactive.CreatorEditor.UI.Graphics
 {
@@ -15,6 +14,7 @@ namespace Innoactive.CreatorEditor.UI.Graphics
 
         public override void Draw()
         {
+            GUI.color = CurrentColor;
             EditorDrawingHelper.DrawCircle(Owner.Position, Owner.BoundingBox.width / 2f, CurrentColor);
 
             GUIStyle labelStyle = new GUIStyle

--- a/Editor/UI/Graphics/Renderers/CreateTransitionButtonRenderer.cs
+++ b/Editor/UI/Graphics/Renderers/CreateTransitionButtonRenderer.cs
@@ -14,19 +14,9 @@ namespace Innoactive.CreatorEditor.UI.Graphics
 
         public override void Draw()
         {
-            GUI.color = CurrentColor;
             EditorDrawingHelper.DrawCircle(Owner.Position, Owner.BoundingBox.width / 2f, CurrentColor);
-
-            GUIStyle labelStyle = new GUIStyle
-            {
-                alignment = TextAnchor.MiddleCenter,
-                normal = { textColor = TextColor },
-                wordWrap = false,
-            };
-            GUI.color = Color.gray;
             Rect iconBoundingBox = new Rect(Owner.Position.x - (iconSize / 2f), Owner.Position.y - (iconSize / 2f), iconSize, iconSize);
-            GUI.DrawTexture(iconBoundingBox, plusIcon.Texture);
-            GUI.color = CurrentColor;
+            EditorDrawingHelper.DrawTexture(iconBoundingBox, plusIcon.Texture, Color.gray);
         }
 
         public override Color NormalColor

--- a/Editor/UI/Graphics/Renderers/EntryJointRenderer.cs
+++ b/Editor/UI/Graphics/Renderers/EntryJointRenderer.cs
@@ -14,21 +14,9 @@ namespace Innoactive.CreatorEditor.UI.Graphics
 
         public override void Draw()
         {
-            GUI.color = CurrentColor;
-            Rect iconRect = new Rect(Owner.Position.x - iconSize / 2f, Owner.Position.y - iconSize / 2f, iconSize, iconSize);
-
             EditorDrawingHelper.DrawCircle(Owner.Position, Owner.BoundingBox.width / 4f, CurrentColor);
-
-            GUIStyle labelStyle = new GUIStyle
-            {
-                alignment = TextAnchor.MiddleCenter,
-                normal = { textColor = TextColor },
-                wordWrap = false,
-            };
-
-            GUI.color = Color.gray;
-            GUI.DrawTexture(iconRect, ingoingIcon.Texture);
-            GUI.color = CurrentColor;
+            Rect iconRect = new Rect(Owner.Position.x - iconSize / 2f, Owner.Position.y - iconSize / 2f, iconSize, iconSize);
+            EditorDrawingHelper.DrawTexture(iconRect, ingoingIcon.Texture, Color.gray);
         }
 
         public override Color NormalColor

--- a/Editor/UI/Graphics/Renderers/EntryJointRenderer.cs
+++ b/Editor/UI/Graphics/Renderers/EntryJointRenderer.cs
@@ -1,6 +1,5 @@
 using Innoactive.CreatorEditor.UI.Graphics.Renderers;
 using UnityEngine;
-using UnityEditor;
 
 namespace Innoactive.CreatorEditor.UI.Graphics
 {
@@ -15,10 +14,11 @@ namespace Innoactive.CreatorEditor.UI.Graphics
 
         public override void Draw()
         {
+            GUI.color = CurrentColor;
             Rect iconRect = new Rect(Owner.Position.x - iconSize / 2f, Owner.Position.y - iconSize / 2f, iconSize, iconSize);
 
             EditorDrawingHelper.DrawCircle(Owner.Position, Owner.BoundingBox.width / 4f, CurrentColor);
-            
+
             GUIStyle labelStyle = new GUIStyle
             {
                 alignment = TextAnchor.MiddleCenter,

--- a/Editor/UI/Graphics/Renderers/EntryNodeRenderer.cs
+++ b/Editor/UI/Graphics/Renderers/EntryNodeRenderer.cs
@@ -8,7 +8,7 @@ namespace Innoactive.CreatorEditor.UI.Graphics
     {
         private static int LabelWidth = 30;
         private static int LabelHeight = 50;
-    
+
         /// <inheritdoc />
         public override Color NormalColor
         {

--- a/Editor/UI/Graphics/Renderers/ExitJointRenderer.cs
+++ b/Editor/UI/Graphics/Renderers/ExitJointRenderer.cs
@@ -14,6 +14,7 @@ namespace Innoactive.CreatorEditor.UI.Graphics
 
         public override void Draw()
         {
+            GUI.color = CurrentColor;
             Rect iconRect = new Rect(Owner.Position.x - iconSize / 2f, Owner.Position.y - iconSize / 2f, iconSize, iconSize);
 
             EditorDrawingHelper.DrawCircle(Owner.Position, Owner.BoundingBox.width / 2f, CurrentColor);

--- a/Editor/UI/Graphics/Renderers/ExitJointRenderer.cs
+++ b/Editor/UI/Graphics/Renderers/ExitJointRenderer.cs
@@ -14,9 +14,6 @@ namespace Innoactive.CreatorEditor.UI.Graphics
 
         public override void Draw()
         {
-            GUI.color = CurrentColor;
-            Rect iconRect = new Rect(Owner.Position.x - iconSize / 2f, Owner.Position.y - iconSize / 2f, iconSize, iconSize);
-
             EditorDrawingHelper.DrawCircle(Owner.Position, Owner.BoundingBox.width / 2f, CurrentColor);
 
             if (Owner.DragDelta.magnitude > Owner.BoundingBox.width / 2f)
@@ -24,9 +21,8 @@ namespace Innoactive.CreatorEditor.UI.Graphics
                 EditorDrawingHelper.DrawArrow(Owner.Position, Owner.Position + Owner.DragDelta, CurrentColor, 40f, 10f);
             }
 
-            GUI.color = Color.gray;
-            GUI.DrawTexture(iconRect, outgoingIcon.Texture);
-            GUI.color = CurrentColor;
+            Rect iconRect = new Rect(Owner.Position.x - iconSize / 2f, Owner.Position.y - iconSize / 2f, iconSize, iconSize);
+            EditorDrawingHelper.DrawTexture(iconRect, outgoingIcon.Texture, Color.gray);
         }
 
         public override Color NormalColor

--- a/Editor/UI/Graphics/Renderers/StepNodeRenderer.cs
+++ b/Editor/UI/Graphics/Renderers/StepNodeRenderer.cs
@@ -65,7 +65,6 @@ namespace Innoactive.CreatorEditor.UI.Graphics.Renderers
 
         public override void Draw()
         {
-            GUI.color = TextColor;
             EditorDrawingHelper.DrawRoundedRect(Owner.BoundingBox, CurrentColor, 10f);
 
             IValidationHandler validation = EditorConfigurator.Instance.Validation;

--- a/Editor/UI/Graphics/Renderers/StepNodeRenderer.cs
+++ b/Editor/UI/Graphics/Renderers/StepNodeRenderer.cs
@@ -65,8 +65,8 @@ namespace Innoactive.CreatorEditor.UI.Graphics.Renderers
 
         public override void Draw()
         {
+            GUI.color = TextColor;
             EditorDrawingHelper.DrawRoundedRect(Owner.BoundingBox, CurrentColor, 10f);
-
 
             IValidationHandler validation = EditorConfigurator.Instance.Validation;
             if (validation.IsAllowedToValidate())

--- a/Runtime/Utils/LockObjectsOnSceneStart.cs.meta
+++ b/Runtime/Utils/LockObjectsOnSceneStart.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9e218973d8ce7b141a938229d9877d26
+guid: 4e1df6fc6061d30438c3c240b7fbb850
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Runtime/Utils/LockObjectsOnSceneStart.cs.meta
+++ b/Runtime/Utils/LockObjectsOnSceneStart.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4e1df6fc6061d30438c3c240b7fbb850
+guid: 9e218973d8ce7b141a938229d9877d26
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
### Description
The color of the hover effect of the transition joints spilled over to other joints.

**Before fix:**
![transition_bug](https://user-images.githubusercontent.com/6626589/103297984-b9ee0400-49f9-11eb-9a02-9ebdf58e4700.gif)

**After fix:**
![transition_bugfix](https://user-images.githubusercontent.com/6626589/103297992-be1a2180-49f9-11eb-86d7-b558dbf6bcb9.gif)

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?
Manual UI testing.

### Checklist
<!--- Make sure your PR meets the following criteria before opening it. -->

- [x] My code follows the [Coding Conventions](#coding-conventions)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules