### PR TITLE
The Dependency Manager now supports versioning and samples importing TRNG-1349

### DIFF
--- a/Editor/PackageManager/Dependency.cs
+++ b/Editor/PackageManager/Dependency.cs
@@ -90,7 +90,7 @@ namespace Innoactive.CreatorEditor.PackageManager
         {
             IEnumerable<Sample> samples = Sample.FindByPackage(Package, Version);
 
-            if (samples != null && samples.Any())
+            if (Samples != null && samples != null && samples.Any())
             {
                 foreach (Sample sample in samples)
                 {

--- a/Editor/PackageManager/Dependency.cs
+++ b/Editor/PackageManager/Dependency.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
+using UnityEngine;
 using UnityEditor;
 using UnityEditor.PackageManager.UI;
-using UnityEngine;
 
 namespace Innoactive.CreatorEditor.PackageManager
 {

--- a/Editor/PackageManager/Dependency.cs
+++ b/Editor/PackageManager/Dependency.cs
@@ -1,4 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.PackageManager.UI;
+using UnityEngine;
 
 namespace Innoactive.CreatorEditor.PackageManager
 {
@@ -13,10 +18,20 @@ namespace Innoactive.CreatorEditor.PackageManager
         public virtual string Package { get; } = "";
 
         /// <summary>
+        /// A string representing the version of the package.
+        /// </summary>
+        public virtual string Version { get; internal set; } = "";
+
+        /// <summary>
         /// Priority lets you tweak in which order each <see cref="Dependency"/> will be performed.
         /// The priority is considered from lowest to highest.
         /// </summary>
         public virtual int Priority { get; } = 0;
+
+        /// <summary>
+        /// Collection of samples to be imported from the Unity Package.
+        /// </summary>
+        public virtual string[] Samples { get; } = null;
 
         /// <summary>
         /// A list of layers to be added.
@@ -47,6 +62,7 @@ namespace Innoactive.CreatorEditor.PackageManager
                     {
                         EmitOnEnabled();
                         AddMissingLayers();
+                        ImportPackageSamples();
                     }
                     else
                     {
@@ -68,6 +84,24 @@ namespace Innoactive.CreatorEditor.PackageManager
         protected virtual void EmitOnDisabled()
         {
             OnPackageDisabled?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void ImportPackageSamples()
+        {
+            IEnumerable<Sample> samples = Sample.FindByPackage(Package, Version);
+
+            if (samples != null && samples.Any())
+            {
+                foreach (Sample sample in samples)
+                {
+                    if (Samples.Any(s => s == sample.displayName && sample.isImported == false))
+                    {
+                        sample.Import();
+                        AssetDatabase.Refresh();
+                        Debug.Log($"{sample.displayName} was imported.");
+                    }
+                }
+            }
         }
 
         private void AddMissingLayers()

--- a/Editor/PackageManager/DependencyManager.cs
+++ b/Editor/PackageManager/DependencyManager.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Innoactive.Creator.Core.Utils;
 using UnityEditor;


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

The Dependency Manager can now install packages at specific version numbers and also import samples from the packages.

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->


Either import the Creator to a new Unity project or go `Help > Reset Packages to defaults`, all packages should be retrieved properly.