### PR TITLE
The Step Inspector no longer saves references when the RuntimeConfigurator is missing TRNG-1375

### DIFF
--- a/Editor/UI/Drawers/UniqueNameReferenceDrawer.cs
+++ b/Editor/UI/Drawers/UniqueNameReferenceDrawer.cs
@@ -56,7 +56,7 @@ namespace Innoactive.CreatorEditor.UI.Drawers
 
             string newUniqueName = GetIDFromSelectedObject(selectedSceneObject, valueType, oldUniqueName);
 
-            if (oldUniqueName != newUniqueName && RuntimeConfigurator.Exists)
+            if (oldUniqueName != newUniqueName)
             {
                 RevertableChangesHandler.Do(
                     new CourseCommand(

--- a/Editor/UI/Drawers/UniqueNameReferenceDrawer.cs
+++ b/Editor/UI/Drawers/UniqueNameReferenceDrawer.cs
@@ -26,6 +26,11 @@ namespace Innoactive.CreatorEditor.UI.Drawers
         /// <inheritdoc />
         public override Rect Draw(Rect rect, object currentValue, Action<object> changeValueCallback, GUIContent label)
         {
+            if (RuntimeConfigurator.Exists == false)
+            {
+                return rect;
+            }
+
             isUndoOperation = false;
             UniqueNameReference uniqueNameReference = (UniqueNameReference)currentValue;
             PropertyInfo valueProperty = currentValue.GetType().GetProperty("Value");
@@ -51,7 +56,7 @@ namespace Innoactive.CreatorEditor.UI.Drawers
 
             string newUniqueName = GetIDFromSelectedObject(selectedSceneObject, valueType, oldUniqueName);
 
-            if (oldUniqueName != newUniqueName)
+            if (oldUniqueName != newUniqueName && RuntimeConfigurator.Exists)
             {
                 RevertableChangesHandler.Do(
                     new CourseCommand(


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

**Fixes**: An issue that made it possible to try to access training scene objects even when they are not present (by switching scenes), consequently a missing reference was saved.

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->


- Open any training course
- Create a new object
- Reference that new object into any step
- Save and create a new scene (Ctrl+N)

> A missing reference error should be shown in the console, this PR fixes that.

- Open the original scene and look for the previously created object in the training

> The reference is missing, this PR fixes that.