### PR TITLE
Maximizing creator tabs does not crash unity anymore

### DIFF
--- a/Editor/DefaultEditingStrategy.cs
+++ b/Editor/DefaultEditingStrategy.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using Innoactive.Creator.Core;
@@ -20,26 +21,14 @@ namespace Innoactive.CreatorEditor
         /// <inheritdoc/>
         public void HandleNewCourseWindow(CourseWindow window)
         {
-            if (courseWindow != null && courseWindow != window)
-            {
-                courseWindow.Close();
-            }
-
             courseWindow = window;
-
             courseWindow.SetCourse(CurrentCourse);
         }
 
         /// <inheritdoc/>
         public void HandleNewStepWindow(StepWindow window)
         {
-            if (stepWindow != null && stepWindow != window)
-            {
-                stepWindow.Close();
-            }
-
             stepWindow = window;
-
             if (courseWindow == null || courseWindow.Equals(null))
             {
                 HandleCurrentStepChanged(null);
@@ -67,21 +56,11 @@ namespace Innoactive.CreatorEditor
             {
                 CourseAssetManager.Save(CurrentCourse);
             }
-
-            if (stepWindow != null)
-            {
-                stepWindow.Close();
-            }
         }
 
         /// <inheritdoc/>
         public void HandleStepWindowClosed(StepWindow window)
         {
-            if (stepWindow != window)
-            {
-                return;
-            }
-
             if (CurrentCourse != null)
             {
                 CourseAssetManager.Save(CurrentCourse);
@@ -97,6 +76,10 @@ namespace Innoactive.CreatorEditor
             {
                 courseWindow = EditorWindow.GetWindow<CourseWindow>();
                 courseWindow.minSize = new Vector2(400f, 100f);
+            }
+            else
+            {
+                courseWindow.Focus();
             }
         }
 
@@ -125,11 +108,14 @@ namespace Innoactive.CreatorEditor
             if (courseWindow != null)
             {
                 courseWindow.SetCourse(CurrentCourse);
+                if (stepWindow != null)
+                {
+                    stepWindow.SetStep(courseWindow.GetChapter()?.ChapterMetadata.LastSelectedStep);
+                }
             }
-
-            if (stepWindow != null)
+            else if (stepWindow != null)
             {
-                stepWindow.SetStep(courseWindow.GetChapter()?.ChapterMetadata.LastSelectedStep);
+                stepWindow.SetStep(null);
             }
         }
 
@@ -151,7 +137,7 @@ namespace Innoactive.CreatorEditor
         {
             if (stepWindow != null)
             {
-                if (step != null &&  EditorConfigurator.Instance.Validation.IsAllowedToValidate())
+                if (step != null && EditorConfigurator.Instance.Validation.IsAllowedToValidate())
                 {
                     EditorConfigurator.Instance.Validation.Validate(step.Data, CurrentCourse);
                 }

--- a/Editor/UI/Windows/StepWindow.cs
+++ b/Editor/UI/Windows/StepWindow.cs
@@ -1,7 +1,5 @@
 using UnityEditor;
 using UnityEngine;
-using UnityEditor.SceneManagement;
-using UnityEngine.SceneManagement;
 using System.Collections.Generic;
 using Innoactive.Creator.Core;
 using Innoactive.CreatorEditor.Tabs;
@@ -31,13 +29,12 @@ namespace Innoactive.CreatorEditor.UI.Windows
         /// </summary>
         public static void ShowInspector()
         {
-            if (EditorUtils.IsWindowOpened<StepWindow>())
-            {
-                return;
-            }
+            GetInstance().Repaint();
+        }
 
-            StepWindow instance = GetWindow<StepWindow>("Step", false);
-            instance.Repaint();
+        public static StepWindow GetInstance(bool focus = false)
+        {
+            return GetWindow<StepWindow>("Step Inspector", focus);
         }
 
         private void OnEnable()
@@ -70,8 +67,6 @@ namespace Innoactive.CreatorEditor.UI.Windows
 
         private void OnGUI()
         {
-            titleContent = new GUIContent("Step Inspector");
-
             if (step == null)
             {
                 return;


### PR DESCRIPTION
### Description
Step Inspector will not get closed when CourseWindow closes, which applied a strange chain reaction earlier, leading to freezing unity completely.

New behavior: 
* StepInspector is not closed when CourseWindow is closed
* StepInspector target step is set to null when no CourseWindow is open and the training is changed

**Fixes**: 
* TRNG-1366


### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
By Hand!

**Test Configuration**:
Nothing else required.
