### PR TITLE
refactor: allow to return lockables without required ones

### DIFF
--- a/Runtime/AssemblyAttributes.cs
+++ b/Runtime/AssemblyAttributes.cs
@@ -3,3 +3,4 @@
 [assembly: InternalsVisibleTo("Innoactive.CreatorEditor")]
 [assembly: InternalsVisibleTo("Innoactive.Creator.Core.Tests")]
 [assembly: InternalsVisibleTo("Innoactive.Creator.Core.Tests.Editmode")]
+[assembly: InternalsVisibleTo("Innoactive.Creator.DesktopInteraction")]

--- a/Runtime/Properties/PropertyReflectionHelper.cs
+++ b/Runtime/Properties/PropertyReflectionHelper.cs
@@ -39,7 +39,7 @@ namespace Innoactive.Creator.Core
             return result;
         }
 
-        public static List<LockablePropertyData> ExtractLockablePropertiesFromConditions(IConditionData data)
+        public static List<LockablePropertyData> ExtractLockablePropertiesFromConditions(IConditionData data, bool alsoRequired = true)
         {
             List<MemberInfo> memberInfo = data.GetType()
                 .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
@@ -69,15 +69,24 @@ namespace Innoactive.Creator.Core
                     return;
                 }
 
-                Type refType = ReflectionUtils
-                    .GetConcreteImplementationsOf(reference.GetReferenceType())
-                    .Where(typeof(LockableProperty).IsAssignableFrom)
-                    .FirstOrDefault(type => Enumerable.All(type.Assembly.GetReferencedAssemblies(),
-                        assemblyName => UnitTestChecker.IsUnitTesting || (assemblyName.Name != "UnityEditor" && assemblyName.Name != "nunit.framework")));
+                IEnumerable<Type> refs = ReflectionUtils.GetConcreteImplementationsOf(reference.GetReferenceType());
+                refs = refs.Where(typeof(LockableProperty).IsAssignableFrom);
 
+                if (UnitTestChecker.IsUnitTesting == false)
+                {
+                    refs = refs.Where(type => type.Assembly.GetReferencedAssemblies().All(name => name.Name != "nunit.framework"));
+                    refs = refs.Where(type => type.Assembly.GetReferencedAssemblies().All(name => name.Name != "UnityEditor"));
+                }
+
+                Type refType = refs.FirstOrDefault();
                 if (refType != null)
                 {
-                    IEnumerable<Type> types = GetLockableDependenciesFrom(refType);
+                    IEnumerable<Type> types = new[] {refType};
+                    if (alsoRequired)
+                    {
+                        types = GetLockableDependenciesFrom(refType);
+                    }
+
                     foreach (Type type in types)
                     {
                         LockableProperty property = GetProperty(reference, type);

--- a/Runtime/Properties/PropertyReflectionHelper.cs
+++ b/Runtime/Properties/PropertyReflectionHelper.cs
@@ -39,7 +39,12 @@ namespace Innoactive.Creator.Core
             return result;
         }
 
-        public static List<LockablePropertyData> ExtractLockablePropertiesFromConditions(IConditionData data, bool alsoRequired = true)
+        /// <summary>
+        /// Extracts all <see cref="LockableProperties"/> from given condition.
+        /// </summary>
+        /// <param name="data">Condition to be used for extraction</param>
+        /// <param name="checkRequiredComponentsToo">if true the [RequiredComponents] will be checked and added too.</param>
+        public static List<LockablePropertyData> ExtractLockablePropertiesFromConditions(IConditionData data, bool checkRequiredComponentsToo = true)
         {
             List<MemberInfo> memberInfo = data.GetType()
                 .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
@@ -82,7 +87,7 @@ namespace Innoactive.Creator.Core
                 if (refType != null)
                 {
                     IEnumerable<Type> types = new[] {refType};
-                    if (alsoRequired)
+                    if (checkRequiredComponentsToo)
                     {
                         types = GetLockableDependenciesFrom(refType);
                     }


### PR DESCRIPTION
### Description
Reworked the method a little bit to make it easier to understand, added the possibility to not include in required properties and opened the internal stuff for desktop mode which is required very soon.