### PR TITLE
chore: renamed assembly

### DIFF
--- a/Runtime/AssemblyAttributes.cs
+++ b/Runtime/AssemblyAttributes.cs
@@ -3,4 +3,4 @@
 [assembly: InternalsVisibleTo("Innoactive.CreatorEditor")]
 [assembly: InternalsVisibleTo("Innoactive.Creator.Core.Tests")]
 [assembly: InternalsVisibleTo("Innoactive.Creator.Core.Tests.Editmode")]
-[assembly: InternalsVisibleTo("Innoactive.Creator.DesktopInteraction")]
+[assembly: InternalsVisibleTo("Innoactive.Creator.DesktopMode")]


### PR DESCRIPTION
### Description
Desktop Mode got moved and renamed into a proper assembly, which requires this renaming.