### PR TITLE
fix: add basic_ui to assembly symbol checker

### DIFF
--- a/Editor/Unity/AssemblySymbolChecker.cs
+++ b/Editor/Unity/AssemblySymbolChecker.cs
@@ -13,6 +13,7 @@ internal class AssemblySymbolChecker
     {
         CheckForClass("Innoactive.Creator.Core", "Innoactive.Creator.Core.Behaviors.BehaviorSequence", "BASIC_CONDITION_BEHAVIORS");
         CheckForAssembly("Innoactive.Creator.BasicInteraction", "BASIC_INTERACTION");
+        CheckForAssembly("Innoactive.Creator.BasicUI", "BASIC_UI");
     }
 
     /// <summary>


### PR DESCRIPTION
### Description
Adds/removes BASIC_UI as define symbol automatically.

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Removed it, reload Unity.
