### PR TITLE
fix: in edtior core is still referencing UnityEditor which is breaks …

### DIFF
--- a/Runtime/Properties/PropertyReflectionHelper.cs
+++ b/Runtime/Properties/PropertyReflectionHelper.cs
@@ -145,7 +145,10 @@ namespace Innoactive.Creator.Core
             if (UnitTestChecker.IsUnitTesting == false)
             {
                 refs = refs.Where(type => type.Assembly.GetReferencedAssemblies().All(name => name.Name != "nunit.framework"));
-                refs = refs.Where(type => type.Assembly.GetReferencedAssemblies().All(name => name.Name != "UnityEditor"));
+                if (Application.isEditor == false)
+                {
+                    refs = refs.Where(type => type.Assembly.GetReferencedAssemblies().All(name => name.Name != "UnityEditor"));
+                }
             }
 
             return refs;


### PR DESCRIPTION
In Editor the core assembly has an UnityEditor reference which excludes correct classes from reflection.