### PR TITLE
Dependency Versioning TRNG-1462

### DIFF
--- a/Editor/PackageManager/Dependency.cs
+++ b/Editor/PackageManager/Dependency.cs
@@ -76,6 +76,16 @@ namespace Innoactive.CreatorEditor.PackageManager
 
         private bool isEnabled;
 
+        protected Dependency()
+        {
+            if (string.IsNullOrEmpty(Package) && Package.Contains('@'))
+            {
+                string[] packageData = Package.Split('@');
+                Package = packageData.First();
+                Version = packageData.Last();
+            }
+        }
+
         protected virtual void EmitOnEnabled()
         {
             OnPackageEnabled?.Invoke(this, EventArgs.Empty);

--- a/Editor/PackageManager/DependencyManager.cs
+++ b/Editor/PackageManager/DependencyManager.cs
@@ -81,9 +81,13 @@ namespace Innoactive.CreatorEditor.PackageManager
                 int index = dependenciesList.FindIndex(item => item == dependency);
                 EditorUtility.DisplayProgressBar("Importing Creator dependencies", $"Fetching {dependency.Package}", index * percentage);
 
-                if (PackageOperationsManager.IsPackageLoaded(dependency.Package))
+                if (PackageOperationsManager.IsPackageLoaded(dependency.Package, dependency.Version))
                 {
-                    dependency.Version = PackageOperationsManager.GetInstalledPackageVersion(dependency.Package);
+                    if (string.IsNullOrEmpty(dependency.Version))
+                    {
+                        dependency.Version = PackageOperationsManager.GetInstalledPackageVersion(dependency.Package);
+                    }
+
                     dependency.IsEnabled = true;
                 }
                 else

--- a/Editor/PackageManager/PackageOperationsManager.cs
+++ b/Editor/PackageManager/PackageOperationsManager.cs
@@ -86,6 +86,12 @@ namespace Innoactive.CreatorEditor.PackageManager
                 return;
             }
 
+            if (IsPackageLoaded(package) && string.IsNullOrEmpty(version) == false)
+            {
+                PackageInfo installedPackage = Packages.First(packageInfo => packageInfo.name == package);
+                EditorUtility.DisplayDialog($"{installedPackage.displayName} Upgrade", $"{installedPackage.displayName} will be upgraded from v{installedPackage.version} to v{version}." , "Continue");
+            }
+
             if (package.Contains("@") == false && string.IsNullOrEmpty(version) == false)
             {
                 package = $"{package}@{version}";
@@ -148,20 +154,23 @@ namespace Innoactive.CreatorEditor.PackageManager
         /// <remarks>If <paramref name="package"/> already contains an embedded version, <paramref name="version"/> will be ignored.</remarks>
         public static bool IsPackageLoaded(string package, string version = null)
         {
+            if (string.IsNullOrEmpty(package))
+            {
+                throw new ArgumentException($"Parameter '{nameof(package)}' is null or empty.");
+            }
+
             if (package.Contains('@'))
             {
                 string[] packageData = package.Split('@');
-                return Packages != null && Packages.Any(packageInfo => packageInfo.name == packageData.First() && packageInfo.version == packageData.Last());
+                return Packages.Any(packageInfo => packageInfo.name == packageData.First() && packageInfo.version == packageData.Last());
             }
 
             if (string.IsNullOrEmpty(version))
             {
-                return Packages != null && Packages.Any(packageInfo => packageInfo.name == package);
+                return Packages.Any(packageInfo => packageInfo.name == package);
             }
-            else
-            {
-                return Packages != null && Packages.Any(packageInfo => packageInfo.name == package && packageInfo.version == version);
-            }
+
+            return Packages.Any(packageInfo => packageInfo.name == package && packageInfo.version == version);
         }
 
         /// <summary>

--- a/Editor/PackageManager/PackageOperationsManager.cs
+++ b/Editor/PackageManager/PackageOperationsManager.cs
@@ -98,7 +98,7 @@ namespace Innoactive.CreatorEditor.PackageManager
             }
 
             AddRequest addRequest = Client.Add(package);
-            Debug.Log($"Enabling package: {package}, Version: {(string.IsNullOrEmpty(version) ? "latest" : version)}.");
+            Debug.Log($"Enabling package: {package.Split('@').First()}, Version: {(string.IsNullOrEmpty(version) ? "latest" : version)}.");
 
             while (addRequest.IsCompleted == false)
             {
@@ -112,7 +112,7 @@ namespace Innoactive.CreatorEditor.PackageManager
             else
             {
                 OnPackageEnabled?.Invoke(null, new PackageEnabledEventArgs(addRequest.Result));
-                Debug.Log($"The package '{addRequest.Result.displayName} version {addRequest.Result.version}' has been automatically added");
+                Debug.Log($"The package '{addRequest.Result.displayName}' version '{addRequest.Result.version}' has been automatically added");
             }
         }
 


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

If provided, dependencies are now always loaded with a specific version.

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**Given:** 
```csharp
public class XRInteractionPackageEnabler : Dependency
{        
    /// <inheritdoc/>
    public override string Package { get; } = "com.unity.xr.interaction.toolkit";
    
    /// <inheritdoc/>
    public override string Version { get; internal set; } = "1.0.0-pre.2";

    /// <inheritdoc/>
    public override string[] Samples { get; } = { "Default Input Actions", "XR Device Simulator" };

    /// <inheritdoc/>
    public override int Priority { get; } = 4;
    
    /// <inheritdoc/>
    protected override string[] Layers { get; } = {"XR Teleport"};
}
```

**When:**
 
- Manually switching the XRIT version on the package manager.
- Help > Reset packages to default.
- Delete the package folder at the project root.

**Then:**

XRIT must always be at `1.0.0-pre.2` additionally, a warning dialog should appear if a different version is found.