### PR TITLE
The Creator now always install requested XR SDK TRNG-1465

### DIFF
--- a/Editor/Innoactive.CreatorEditor.asmdef
+++ b/Editor/Innoactive.CreatorEditor.asmdef
@@ -3,9 +3,7 @@
     "references": [
         "GUID:c8561f9de838ac04d8feeda695bc572d",
         "GUID:e40ba710768534012815d3193fa296cb",
-        "GUID:f9fe0089ec81f4079af78eb2287a6163",
-        "GUID:4af21795022437d4bb139a86514b9ff9",
-        "GUID:3d9f59ae91c131e408fec0e5f661c340"
+        "GUID:f9fe0089ec81f4079af78eb2287a6163"
     ],
     "includePlatforms": [
         "Editor"
@@ -19,7 +17,7 @@
     "versionDefines": [
         {
             "name": "com.unity.xr.management",
-            "expression": "",
+            "expression": "4.0.1",
             "define": "UNITY_XR_MANAGEMENT"
         },
         {

--- a/Editor/XRUtils/XRManagementPackageEnabler.cs
+++ b/Editor/XRUtils/XRManagementPackageEnabler.cs
@@ -8,10 +8,16 @@ namespace Innoactive.CreatorEditor.XRUtils
     /// <summary>
     /// Enables the XR Plug-in Management.
     /// </summary>
+    /// <remarks>
+    /// The purpose of this class is to ensure the XR SDKs are enabled after the XR Plugin Management is installed.
+    /// </remarks>
     internal sealed class XRManagementPackageEnabler : Dependency, IDisposable
     {
         /// <inheritdoc/>
         public override string Package { get; } = "com.unity.xr.management";
+
+        /// <inheritdoc/>
+        public override string Version { get; internal set; } = "4.0.1";
 
         /// <inheritdoc/>
         public override int Priority { get; } = 1;

--- a/Editor/XRUtils/XRProviders/XRProvider.cs
+++ b/Editor/XRUtils/XRProviders/XRProvider.cs
@@ -2,6 +2,7 @@
 using System;
 using UnityEditor;
 using Innoactive.CreatorEditor.PackageManager;
+using UnityEngine;
 
 namespace Innoactive.CreatorEditor.XRUtils
 {
@@ -22,10 +23,15 @@ namespace Innoactive.CreatorEditor.XRUtils
             OnPackageEnabled -= InitializeXRLoader;
         }
 
-        protected virtual void InitializeXRLoader(object sender, EventArgs e)
+        protected virtual async void InitializeXRLoader(object sender, EventArgs e)
         {
             OnPackageEnabled -= InitializeXRLoader;
-            XRLoaderHelper.EnableLoader(Package, XRLoaderName);
+            bool wasLoaderEnabled = await XRLoaderHelper.TryToEnableLoader(XRLoaderName);
+
+            if (wasLoaderEnabled == false)
+            {
+                Debug.LogWarning($"{XRLoaderName} could not be loaded. Enable it manually here:\nEdit > Project Settings... > XR Plug-in Management.");
+            }
         }
     }
 }


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

The XR Plugin Management didn't expose any API to enable XR Loaders, we came up with a solution that required reflection to enable the XR SDK that the user selected in the wizard. The newest version of the package now exposes an API to properly load the XR Loaders and the legacy private method no longer works on old Unity 1029 LTS provoking these errors:

![image](https://user-images.githubusercontent.com/6911992/109872693-0f9a9300-7c6d-11eb-9531-dc1c2e6804b2.png)

This PR addressed both issues.

### Type of change
<!--- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Either try a new project, import the creator, and select any xr sdk or delete the XR folder (if present) and every folder at root but Assets and then open the project again, and select any xr sdk.

The selected SDK must always be enabled after the installation and no errors should be during the process.