### PR TITLE
fix: higher dependency versions are now supported TRNG-1513

### DIFF
--- a/Editor/PackageManager/PackageOperationsManager.cs
+++ b/Editor/PackageManager/PackageOperationsManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using UnityEditor;
@@ -162,15 +163,13 @@ namespace Innoactive.CreatorEditor.PackageManager
             if (package.Contains('@'))
             {
                 string[] packageData = package.Split('@');
-                return Packages.Any(packageInfo => packageInfo.name == packageData.First() && packageInfo.version == packageData.Last());
+                string packageName = packageData.First();
+                string packageVersion = packageData.Last();
+
+                return IsPackageInstalled(packageName, packageVersion);
             }
 
-            if (string.IsNullOrEmpty(version))
-            {
-                return Packages.Any(packageInfo => packageInfo.name == package);
-            }
-
-            return Packages.Any(packageInfo => packageInfo.name == package && packageInfo.version == version);
+            return string.IsNullOrEmpty(version) ? IsPackageInstalled(package) : IsPackageInstalled(package, version);
         }
 
         /// <summary>
@@ -179,6 +178,38 @@ namespace Innoactive.CreatorEditor.PackageManager
         public static string GetInstalledPackageVersion(string package)
         {
             return Packages.First(packageInfo => package.Contains(packageInfo.name))?.version;
+        }
+
+        private static bool IsPackageInstalled(string package)
+        {
+            return Packages.Any(packageInfo => packageInfo.name == package);
+        }
+
+        private static bool IsPackageInstalled(string package, string version)
+        {
+            if (IsPackageInstalled(package))
+            {
+                if (string.IsNullOrEmpty(version))
+                {
+                    return true;
+                }
+
+                PackageInfo packageInfo = Packages.First(pi => pi.name == package);
+
+                return IsVersionInstalledOrSupported(packageInfo, version);
+            }
+
+            return false;
+        }
+
+        private static bool IsVersionInstalledOrSupported(PackageInfo packageInfo, string version)
+        {
+            List<string> packageVersions = packageInfo.versions.all.ToList();
+
+            int currentVersion = packageVersions.IndexOf(packageInfo.version);
+            int targetVersion = packageVersions.IndexOf(version);
+
+            return currentVersion >= targetVersion;
         }
     }
 }


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

If the XR Interaction Toolkit v1.0.0-pre.3 is installed, the Dependency Manager will downgrade to v1.0.0-pre.2, this should only happen if the installed version is lower than the target version.

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Play around installing higher or lower versions of the `XR Interaction Toolkit` or the `XR Plugin Management`