### PR TITLE
fix: issue where the step and workflow editor crash when building

### DIFF
--- a/Editor/UI/Drawers/StepDrawer.cs
+++ b/Editor/UI/Drawers/StepDrawer.cs
@@ -19,7 +19,7 @@ namespace Innoactive.CreatorEditor.UI.Drawers
 
         private static int margin = 3;
         private static int padding = 2;
-        
+
         protected StepDrawer()
         {
             EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
@@ -32,6 +32,11 @@ namespace Innoactive.CreatorEditor.UI.Drawers
 
         public override Rect Draw(Rect rect, object currentValue, Action<object> changeValueCallback, GUIContent label)
         {
+            if (BuildPipeline.isBuildingPlayer)
+            {
+                return rect;
+            }
+
             rect = base.Draw(rect, currentValue, changeValueCallback, label);
 
             Step.EntityData step = (Step.EntityData) currentValue;
@@ -120,7 +125,7 @@ namespace Innoactive.CreatorEditor.UI.Drawers
 
         private void OnPlayModeStateChanged(PlayModeStateChange mode)
         {
-            
+
         }
     }
 }

--- a/Editor/UI/Windows/CourseWindow.cs
+++ b/Editor/UI/Windows/CourseWindow.cs
@@ -231,7 +231,7 @@ namespace Innoactive.CreatorEditor.UI.Windows
 
         private void OnSceneOpened(Scene scene, OpenSceneMode mode)
         {
-            if (RuntimeConfigurator.Exists == false)
+            if (BuildPipeline.isBuildingPlayer == false && RuntimeConfigurator.Exists == false)
             {
                 Close();
             }
@@ -239,7 +239,10 @@ namespace Innoactive.CreatorEditor.UI.Windows
 
         private void OnNewScene(Scene scene, NewSceneSetup setup, NewSceneMode mode)
         {
-            Close();
+            if (BuildPipeline.isBuildingPlayer == false)
+            {
+                Close();
+            }
         }
     }
 }


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

**Fixes**: The Step Inspector and the Workflow Editor no longer crash when Unity is building.

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Build something with those windows open.