### PR TITLE
fix: keybinding creation does not duplicate folder

### DIFF
--- a/Editor/Input/InputEditorUtils.cs
+++ b/Editor/Input/InputEditorUtils.cs
@@ -17,8 +17,15 @@ namespace Innoactive.CreatorEditor.Input
         {
             InputActionAsset defaultBindings = Resources.Load<InputActionAsset>(RuntimeConfigurator.Configuration.DefaultInputActionAssetPath);
 
-            AssetDatabase.CreateFolder("Assets", "Resources");
-            AssetDatabase.CreateFolder("Assets/Resources", "KeyBindings");
+            if (AssetDatabase.IsValidFolder("Assets/Resources") == false)
+            {
+                AssetDatabase.CreateFolder("Assets", "Resources");
+            }
+
+            if (AssetDatabase.IsValidFolder("Assets/Resources/KeyBindings") == false)
+            {
+                AssetDatabase.CreateFolder("Assets/Resources", "KeyBindings");
+            }
 
             AssetDatabase.CopyAsset(AssetDatabase.GetAssetPath(defaultBindings),
                 $"Assets/Resources/{RuntimeConfigurator.Configuration.CustomInputActionAssetPath}.inputactions");


### PR DESCRIPTION
### Description
Check if folder exists because unity actually would create Resources 1-X instead of not creating an existing folder.